### PR TITLE
Possible way to integrate Azure AAD oauth2 token validation into scimgateway

### DIFF
--- a/DataDockerfile
+++ b/DataDockerfile
@@ -1,0 +1,10 @@
+# To build: docker build --force-rm=true -t scimgateway-data:latest .
+# To run: docker run -d --name scimgateway-data -t scimgateway-data:latest
+
+FROM busybox:latest
+MAINTAINER Jeffrey Gilbert
+
+RUN mkdir -p /home/scimgateway/config
+VOLUME /home/scimgateway/config
+
+CMD ["echo", "Data container for scimgateway created and will now shutdown.  No need to run again."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Docker version 1.13.0
+#
+# Depending on your system you  may need to prefix the commands below with sudo.
+#
+# To build:  docker build --force-rm=true -t <projectName>:1.0.0 .
+#   Example:  docker build --force-rm=true -t scimgateway:1.0.0 .
+#
+# To tag as latest:   docker tag <projectName>:1.0.0 <projectName>:latest
+#   Example:   docker tag scimgateway:1.0.0 scimgateway:latest
+#
+# To run:   docker run -d -e NODE_ENV=<environment> -e PORT=<port> -h localhost -p <external port>:<internal port> --name <projectName> <projectName>:latest
+#   Example:   docker run -d -e NODE_ENV=development -e PORT=3000  -h localhost -p 8880:8880 --name scimgateway scimgateway:latest
+
+
+# Debian Jessie linux with node user account and group
+FROM node:6.9.2-slim
+
+# Declare who maintains this Dockerfile
+MAINTAINER Charles Watson <cwatsonx@costco.com>
+
+# Add a Process ID 1 Safety Net.  Specific to debian.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+# Setup environment or env variables with sane defaults.  Note they can be overridden via the command line.
+ENV NODE_ENV np  # Either np or prod.
+ENV PORT 8880
+ENV SEED localhost
+
+# Define your working directory for the node app.
+WORKDIR /home/scimgateway
+ENV NODE_HOME /home/scimgateway
+
+# Add your project info
+ADD ./package.json $NODE_HOME
+
+# Install npm dependencies (exclude test stuff for dependencies)
+RUN . ~/.bashrc && cd $NODE_HOME && npm install --production 2> npm_output.txt && npm cache clear 2> /dev/null
+
+# Copy your project's code to your working directory
+COPY . $NODE_HOME
+
+# Default http port
+EXPOSE 8880
+
+# Start it up
+CMD ["dumb-init", "node", "index.js"]

--- a/config/plugin-testmode.json
+++ b/config/plugin-testmode.json
@@ -25,6 +25,6 @@
         "host": "hostname",
         "port": 99999,
         "username": "username",
-        "password": "ef037d1e57a2242162a811f959d0b2a4"
+        "password": "password"
     }
 }

--- a/config/plugin-testmode.json
+++ b/config/plugin-testmode.json
@@ -4,10 +4,12 @@
         "loglevel": "debug",
         "localhostonly": false,
         "port": 8880,
-        "username": "gwadmin",
-        "password": "password",
+        "authType": "token",
         "oauth": {
-            "accesstoken": null
+            "audience": "00000002-0000-0000-c000-000000000000",
+            "tenantId": "MY_TENANT.onmicrosoft.com",
+            "issuer": "https://sts.windows.net/A_HASH_THAT_REPRESENTS_MY_ISSUER/",
+            "clientId": "A_HASH_THAT_REPRESENTS_MY_CLIENT_ID"
         },
         "certificate": {
             "key": null,
@@ -23,6 +25,6 @@
         "host": "hostname",
         "port": 99999,
         "username": "username",
-        "password": "password"
+        "password": "ef037d1e57a2242162a811f959d0b2a4"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  scimgateway:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    image: scimgateway:latest
+    container_name: scimgateway
+    hostname:
+      scimgateway
+    volumes:
+      - /home/scimgateway/config:/home/scimgateway/config:rw
+    volumes_from:
+      - scimgateway-data
+    ports:
+      - "8880:8880"
+    environment:
+      - ENVIRONMENT=development
+      - PORT=8880
+      - SEED=localhost
+    restart: on-failure:3
+            
+  scimgateway-data:
+    image: scimgateway-data:latest
+    container_name: scimgateway-data
+    build:
+      context: .
+      dockerfile: DataDockerfile

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -13,7 +13,6 @@
 var http = require('http');
 var https = require('https');
 var express = require('express');
-var bearerToken = require('express-bearer-token');
 var EventEmitter = require('events').EventEmitter;
 var dot = require('dot-object');
 var util = require('util');
@@ -42,7 +41,7 @@ var ScimGateway = function () {
     this.notValidAttributes = notValidAttributes;   // exposed to plugin-code
 
     // verify configuration file - scimgateway sub-elements
-    if (!isValidconfig(config, ["localhostonly", "port", "username", "password", "loglevel"])) {
+    if (!isValidconfig(config, ["localhostonly", "port", "authType", "loglevel"])) {
         logger.error(`${gwName} Configurationfile: ${require.resolve(configFile)}`);
         logger.error(`${gwName} Configurationfile have wrong or missing scimgateway sub-elements`);
         logger.error(`${gwName} Stopping...`);
@@ -50,16 +49,7 @@ var ScimGateway = function () {
         // process.exit(1) // may miss unflushed logger updates to logfile
         throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'));
     }
-    var oauthAccessToken = null;
-    if (config.oauth && config.oauth.accesstoken) oauthAccessToken = ScimGateway.prototype.getPassword('scimgateway.oauth.accesstoken', configFile);
-    var gwPassword = ScimGateway.prototype.getPassword('scimgateway.password', configFile);
-    if (!gwPassword && !oauthAccessToken) {
-        logger.error(`${gwName} Scimgateway password decryption failed`);
-        logger.error(`${gwName} Stopping...`);
-        console.log();
-        // process.exit(1) // may miss unflushed logger updates to logfile
-        throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'));
-    }
+
     if (!fs.existsSync(dirLogs)) fs.mkdirSync(dirLogs);
     if (!fs.existsSync(dirConfig + '/wsdls')) fs.mkdirSync(dirConfig + '/wsdls')
     if (!fs.existsSync(dirConfig + '/certs')) fs.mkdirSync(dirConfig + '/certs')
@@ -69,26 +59,101 @@ var ScimGateway = function () {
     this.testmodeusers = scimDef.TestmodeUsers.Resources; // exported and used by plugin-testmode
     this.testmodegroups = scimDef.TestmodeGroups.Resources; // exported and used by plugin-testmode
     var app = express();
-    var basicAuth = require('basic-auth');
 
     app.disable('etag'); // no etag header - disable local browser caching of headers - content type header changes will then be reflected
     app.disable('x-powered-by'); // no nodejs-express information in header
 
-    app.use(bearerToken());
-    app.use(function (req, res, next) { // accepting authentication types basic and token
-        var user = basicAuth(req);
-        if ((!user || user.name !== config.username || user.pass !== gwPassword) && (!req.token || req.token !== oauthAccessToken)) {
-            if (user) logger.error(`${gwName} authentication failed for user "${user.name}"`);
-            else if (req.token) logger.error(`${gwName} authentication failed for bearer token "${req.token}"`);
-            res.setHeader('WWW-Authenticate', 'Basic realm="ScimGateway"');
-            res.status(401).end('Access denied');
-        } else {
-            res.setHeader('Content-Type', 'application/json; charset=utf-8');
-            return next();
-        }
-    });
-    app.use(require('morgan')('combined', { "stream": log.stream }));   // express logging to log.stream (combined/common) instead of: app.use(express.logger('dev'));  /* 'default', 'short', 'tiny', 'dev' */
+    logger.debug(`config.authType: ${config.authType}`);
+    //bearer token
+    var oauthAccessToken = null;
+    //authtoken claims
+    var aud = null;
+    var tenantId = null;
+    var issuer = null;
+    var clientId = null;
+    switch(config.authType) {
+        case 'noauth': //For testing without authentication
+            app.use(function (req, res, next) {
+                res.setHeader('Content-Type', 'application/json; charset=utf-8');
+                return next();
+            });
+            break;
+        case 'basic':
+            var gwPassword = ScimGateway.prototype.getPassword('scimgateway.password', configFile);
+            if (!gwPassword) {
+                logger.error(`${gwName} Scimgateway password decryption failed`);
+                logger.error(`${gwName} Stopping...`);
+                console.log();
+                // process.exit(1) // may miss unflushed logger updates to logfile
+               throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'));
+            }
+            var basicAuth = require('basic-auth');
+            app.use(function (req, res, next) { // accepting authentication types basic
+                var user = basicAuth(req);
+                if (!user || user.name !== config.username || user.pass !== gwPassword) {
+                    if (user) logger.error(`${gwName} authentication failed for user "${user.name}"`);
+                    res.setHeader('WWW-Authenticate', 'Basic realm="ScimGateway"');
+                    res.status(401).end('Access denied');
+                } else {
+                    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+                    return next();
+                }
+            });
+            break;
+        case 'bearer':
+            var bearerToken = require('express-bearer-token');
+            //config.oauth.accesstoken could be renamed to config.oauth.bearertoken to be more accurate. 
+            if (config.oauth && config.oauth.accesstoken) oauthAccessToken = ScimGateway.prototype.getPassword('scimgateway.oauth.accesstoken', configFile);
+            if (!oauthAccessToken) {
+                logger.error(`${gwName} Scimgateway accesstoken decryption failed`);
+                logger.error(`${gwName} Stopping...`);
+                console.log();
+                // process.exit(1) // may miss unflushed logger updates to logfile
+                throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'));
+            }
+            app.use(bearerToken());
+            app.use(function (req, res, next) { // accepting authentication types bearer token
+            if (!req.token || req.token !== oauthAccessToken) {
+                if (req.token) logger.error(`${gwName} authentication failed for bearer token "${req.token}"`);
+                    res.setHeader('WWW-Authenticate', 'Basic realm="ScimGateway"');
+                    res.status(401).end('Access denied');
+                } else {
+                    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+                    return next();
+                }
+            });
+            break;
+        case 'token':
+            var bearerToken = require('express-bearer-token');
+            var aad = require("azure-ad-jwt");
+            if (config.oauth && config.oauth.audience) aud = config.oauth.audience; //ScimGateway.prototype.getPassword('scimgateway.oauth.audience', configFile);
+            if (config.oauth && config.oauth.tenantId) tenantId = config.oauth.tenantId; //ScimGateway.prototype.getPassword('scimgateway.oauth.tenantId', configFile);
+            if (config.oauth && config.oauth.issuer) issuer = config.oauth.issuer; //ScimGateway.prototype.getPassword('scimgateway.oauth.issuer', configFile);
+            if (config.oauth && config.oauth.clientId) clientId = config.oauth.clientId; //ScimGateway.prototype.getPassword('scimgateway.oauth.clientId', configFile);
+            if (!aud || !tenantId || !issuer || !clientId) {
+                logger.error(`${gwName} Scimgateway oauth2-token authentication missing validation parameters.`);
+                logger.error(`${gwName} Stopping...`);
+                console.log();
+                // process.exit(1) // may miss unflushed logger updates to logfile
+                throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'));
+            }
 
+            app.use(bearerToken());
+            app.use(function(req, res, next) { //accepting authentication types oauth2 token
+                aad.verify(req.token, { audience: aud, tenantId: tenantId, issuer: issuer, subject: clientId }, function (err, result) {
+                    if (result) {
+                        //req.user = result; //Put the validated payload in the request object for future use?
+                        return next();
+                    } else {
+                        if (err) logger.error(JSON.stringify(err, null, 2));
+                        res.status(401).end('Access denied');
+                    }
+                });
+            });
+            break;
+        }
+
+    app.use(require('morgan')('combined', { "stream": log.stream }));   // express logging to log.stream (combined/common) instead of: app.use(express.logger('dev'));  /* 'default', 'short', 'tiny', 'dev' */
 
     // Initial connection, step #1: GET /ServiceProviderConfigs
     // If not included => Provisioning will always use GET /Users without any paramenters

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "async": "^2.1.5",
+    "azure-ad-jwt": "^0.2.0",
     "basic-auth": "^1.1.0",
     "callsite": "^1.0.0",
     "dot-object": "^1.5.4",


### PR DESCRIPTION
**This pull request is just a suggestion.**  I suspect you may want to change it up a bit before introducing these changes into the code base.

1. Added dependency **azure-ad-jwt** for token validation.
2. Modified **config/plugin-testmode.js** file by added a property titled **authType**.  Which could be one of four values:  **noauth**, **basic**, **bearer**, **token**
3. Modified **lib/scimgateway.js** auth code so as to use a switch for handling authentication.

lib/scimgateway.js lines 142 to 152 do the heavy lifting for token validation.

I tested all four types of auths each worked fine.
Note the oauth2 token validation took place using Sync Fabric on Azure.  Its passed.

Jeff

PS.  Interesting note and confirmed with Microsoft.  The audience value will always be the same for Sync Fabric integrations.  The number I've provided references AAD and as of now will never differ.  Charley and myself and our contact at Microsoft feel like this is a security design flaw.  We all thought the audience should be the scimgateway app (a unique number).  Oh well...  