### PR TITLE
[BUGFIX] Error handling / SCIM Version

### DIFF
--- a/README.html
+++ b/README.html
@@ -288,26 +288,34 @@ img {
 </head>
 <body>
 <h1>SCIM Gateway</h1>
-<p><a href="https://travis-ci.org/jelhub/scimgateway"><img src="https://travis-ci.org/jelhub/scimgateway.svg" alt="Build Status" /></a> <a href="https://www.npmjs.com/package/scimgateway"><img src="https://img.shields.io/npm/v/scimgateway.svg?style=flat-square&amp;label=latest" alt="npm Version" /></a><a href="https://www.npmjs.com/package/scimgateway"><img src="https://img.shields.io/npm/dt/scimgateway.svg?style=flat-square" alt="npm Downloads" /></a> <a href="https://elshaug.xyz/md/scimgateway#disqus_thread"><img src="https://jelhub.github.io/images/chat.svg" alt="chat disqus" /></a> <a href="https://github.com/jelhub/scimgateway"><img src="https://img.shields.io/github/forks/jelhub/scimgateway.svg?style=social&amp;label=Fork" alt="GitHub forks" /></a>  </p>
+<p><a href="https://travis-ci.org/jelhub/scimgateway"><img src="https://travis-ci.org/jelhub/scimgateway.svg" alt="Build Status" /></a> <a href="https://www.npmjs.com/package/scimgateway"><img src="https://img.shields.io/npm/v/scimgateway.svg?style=flat-square&amp;label=latest" alt="npm Version" /></a><a href="https://www.npmjs.com/package/scimgateway"><img src="https://img.shields.io/npm/dt/scimgateway.svg?style=flat-square" alt="npm Downloads" /></a> <a href="https://elshaug.xyz/md/scimgateway#disqus_thread"><img src="https://jelhub.github.io/images/chat.svg" alt="chat disqus" /></a> <a href="https://github.com/jelhub/scimgateway"><img src="https://img.shields.io/github/forks/jelhub/scimgateway.svg?style=social&amp;label=Fork" alt="GitHub forks" /></a>  
+</p>
 <hr />
-<p>Author: Jarle Elshaug  </p>
-<p>Validated through IdP's:  </p>
+<p>Author: Jarle Elshaug  
+</p>
+<p>Validated through IdP's:  
+</p>
 <ul>
 <li>CA Identity Manager</li>
-<li>Microsoft Azure Active Directory  </li>
+<li>Microsoft Azure Active Directory  
+</li>
 <li>OneLogin</li>
 </ul>
-<p>Latest news:  </p>
+<p>Latest news:  
+</p>
 <ul>
 <li>Codebase moved from callback of h... to the the promise(d) land of async/await</li>
 <li>Supports configuration by environments and external files</li>
 <li>Health monitoring through &quot;/ping&quot; URL, and option for error notifications by email</li>
 <li>Azure AD user provisioning including license management (e.g. Office 365), installed and configured within minutes!</li>
-<li>Includes API Gateway for none SCIM/provisioning (becomes what you want it to become)   </li>
-<li>Running SCIM Gateway as a Docker container  </li>
+<li>Includes API Gateway for none SCIM/provisioning (becomes what you want it to become)   
+</li>
+<li>Running SCIM Gateway as a Docker container  
+</li>
 </ul>
 <h2>Overview</h2>
-<p>With SCIM Gateway we could do user management by using REST based <a href="http://www.simplecloud.info/">SCIM</a> protocol. Gateway will then translate incoming SCIM requests and expose CRUD functionality (create, read, update and delete user/group) towards destinations using endpoint specific protocols. Gateway do not require SCIM to be used, it's also an API Gateway that could be used for other things than user provisioning.  </p>
+<p>With SCIM Gateway we could do user management by using REST based <a href="http://www.simplecloud.info/">SCIM</a> protocol. Gateway will then translate incoming SCIM requests and expose CRUD functionality (create, read, update and delete user/group) towards destinations using endpoint specific protocols. Gateway do not require SCIM to be used, it's also an API Gateway that could be used for other things than user provisioning.  
+</p>
 <p>SCIM Gateway is a standalone product, however this document shows how the gateway could be used by products like CA Identity Manager.</p>
 <p>Using CA Identity Manager, we could setup one or more endpoints of type SCIM pointing to the gateway. Specific ports could then be used for each type of endpoint, and the SCIM Gateway would work like a &quot;CA Connector Server&quot; communicating with endpoints.</p>
 <p><img src="https://jelhub.github.io/images/ScimGateway.svg" /></p>
@@ -366,8 +374,10 @@ One example of usage could be creation of tickets in ServiceDesk/HelpDesk and al
 </ul>
 <h2>Installation</h2>
 <h4>Install Node.js</h4>
-<p>Node.js is a prerequisite and have to be installed on the server.  </p>
-<p><a href="https://nodejs.org/en/download/">Download</a> the windows installer (.msi 64-bit) and install using default options.  </p>
+<p>Node.js is a prerequisite and have to be installed on the server.  
+</p>
+<p><a href="https://nodejs.org/en/download/">Download</a> the windows installer (.msi 64-bit) and install using default options.  
+</p>
 <h4>Install SCIM Gateway</h4>
 <p>Open a command window (run as administrator)<br />
 Create your own package directory e.g. C:\my-scimgateway and install SCIM Gateway within this package.</p>
@@ -379,7 +389,8 @@ npm install scimgateway --save
 
 <p>Please <strong>ignore any error messages</strong> unless soap WSSecurityCert functionality is needed in your custom plugin code. Module soap installation of optional dependency 'ursa' that also includes 'node-gyp' then needs misc. prerequisites to bee manually installed.</p>
 <p><strong>c:\my-scimgateway</strong> will now be <code>&lt;package-root&gt;</code> </p>
-<p>index.js, lib and config directories containing example plugins have been copied to your package from the original scimgateway package located under node_modules.  </p>
+<p>index.js, lib and config directories containing example plugins have been copied to your package from the original scimgateway package located under node_modules.  
+</p>
 <p>If internet connection is blocked, we could install on another machine and copy the scimgateway folder.</p>
 <h4>Startup and verify default Loki plugin</h4>
 <pre><code>node c:\my-scimgateway
@@ -405,22 +416,26 @@ http://localhost:8880/Groups/Admins
 
 <p>For more functionality using browser (post/patch/delete) a REST extension/add-on is needed. 	</p>
 <h4>Upgrade SCIM Gateway</h4>
-<p>Not needed after a fresh install  </p>
+<p>Not needed after a fresh install  
+</p>
 <p>Check if newer versions are available: </p>
 <pre><code>cd c:\my-scimgateway
 npm outdated
 </code></pre>
 
 <p>Lists current, wanted and latest version. No output on screen means we are running the latest version.</p>
-<p>Upgrade to latest minor version:  </p>
+<p>Upgrade to latest minor version:  
+</p>
 <pre><code>cd c:\my-scimgateway
 npm install scimgateway
 </code></pre>
 
-<p>Note, always backup/copy C:\my-scimgateway before upgrading. Custom plugins and corresponding configuration files will not be affected.  </p>
+<p>Note, always backup/copy C:\my-scimgateway before upgrading. Custom plugins and corresponding configuration files will not be affected.  
+</p>
 <p>To force a major upgrade (version x.*.* =&gt; y.*.*) that will brake compability with any existing custom plugins, we have to include the <code>@latest</code> suffix in the install command: <code>npm install scimgateway@latest</code></p>
 <h2>Configuration</h2>
-<p><strong>index.js</strong> defines one or more plugins to be started. We could comment out those we do not need. Default configuration only starts the loki plugin.  </p>
+<p><strong>index.js</strong> defines one or more plugins to be started. We could comment out those we do not need. Default configuration only starts the loki plugin.  
+</p>
 <pre><code>const loki = require('./lib/plugin-loki')
 // const restful = require('./lib/plugin-restful')
 // const forwardinc = require('./lib/plugin-forwardinc')
@@ -430,13 +445,15 @@ npm install scimgateway
 // const azureAD = require('./lib/plugin-azure-ad')
 </code></pre>
 
-<p>Each endpoint plugin needs a JavaScript file (.js) and a configuration file (.json). <strong>They both must have the same naming suffix</strong>. For SAP Hana endpoint we have:  </p>
+<p>Each endpoint plugin needs a JavaScript file (.js) and a configuration file (.json). <strong>They both must have the same naming suffix</strong>. For SAP Hana endpoint we have:  
+</p>
 <blockquote>
 <p>lib\plugin-saphana.js<br />
 config\plugin-saphana.json</p>
 </blockquote>
 <p>Edit specific plugin configuration file according to your needs.<br />
-Below shows an example of config\plugin-saphana.json  </p>
+Below shows an example of config\plugin-saphana.json  
+</p>
 <pre><code>{
   &quot;scimgateway&quot;: {
     &quot;port&quot;: 8884,
@@ -508,9 +525,12 @@ Below shows an example of config\plugin-saphana.json  </p>
 }
 </code></pre>
 
-<p>Configuration file have two main JSON objects: <code>scimgateway</code> and <code>endpoint</code>  </p>
-<p>Definitions in <code>scimgateway</code> object have fixed attributes but values can be modified. This object is used by the core functionality of the SCIM Gateway.  </p>
-<p>Definitions in <code>endpoint</code> object are customized according to our plugin code. Plugin typically need this information for communicating with endpoint  </p>
+<p>Configuration file have two main JSON objects: <code>scimgateway</code> and <code>endpoint</code>  
+</p>
+<p>Definitions in <code>scimgateway</code> object have fixed attributes but values can be modified. This object is used by the core functionality of the SCIM Gateway.  
+</p>
+<p>Definitions in <code>endpoint</code> object are customized according to our plugin code. Plugin typically need this information for communicating with endpoint  
+</p>
 <ul>
 <li>
 <p><strong>port</strong> - Gateway will listen on this port number. Clients (e.g. Provisioning Server) will be using this port number for communicating with the gateway. For endpoint the port is the port number used by plugin for communicating with SAP Hana.  
@@ -605,13 +625,17 @@ Below shows an example of config\plugin-saphana.json  </p>
 <li>
 <p><strong>emailOnError</strong> - Contains configuration for sending error notifications by email. Note, only the first error will be sent until sendInterval have passed </p>
 </li>
-<li><strong>emailOnError.smtp.enabled</strong> - true or false, value set to true will enable email notifications  </li>
-<li><strong>emailOnError.smtp.host</strong> - Mailserver e.g. &quot;smtp.office365.com&quot;  </li>
+<li><strong>emailOnError.smtp.enabled</strong> - true or false, value set to true will enable email notifications  
+</li>
+<li><strong>emailOnError.smtp.host</strong> - Mailserver e.g. &quot;smtp.office365.com&quot;  
+</li>
 <li><strong>emailOnError.smtp.port</strong> - Port used by mailserver e.g. 587, 25 or 465</li>
 <li><strong>emailOnError.smtp.proxy</strong> - If using mailproxy e.g. &quot;http://proxy-host:1234&quot;</li>
 <li><strong>emailOnError.smtp.authenticate</strong> - true or false, set to true will use username/password authentication</li>
-<li><strong>emailOnError.smtp.username</strong> - Mail account for authentication and also the sender of the email, e.g. &quot;user@outlook.com&quot;  </li>
-<li><strong>emailOnError.smtp.password</strong> - Mail account password  </li>
+<li><strong>emailOnError.smtp.username</strong> - Mail account for authentication and also the sender of the email, e.g. &quot;user@outlook.com&quot;  
+</li>
+<li><strong>emailOnError.smtp.password</strong> - Mail account password  
+</li>
 <li><strong>emailOnError.smtp.sendInterval</strong> - Mail notifications on error are deferred until sendInterval <strong>minutes</strong> have passed since the last notification. Default 15 minutes</li>
 <li><strong>emailOnError.smtp.to</strong> - Comma separated list of recipients email addresses e.g: &quot;someone@example.com&quot;</li>
 <li>
@@ -624,7 +648,8 @@ Below shows an example of config\plugin-saphana.json  </p>
 </ul>
 <h4>Configuration notes</h4>
 <ul>
-<li>Setting environment variable <code>SEED</code> will override default password seeding logic.  </li>
+<li>Setting environment variable <code>SEED</code> will override default password seeding logic.  
+</li>
 <li>All configuration can be set based on environment variables. Syntax will then be <code>&quot;process.env.&lt;ENVIRONMENT&gt;&quot;</code> where <code>&lt;ENVIRONMENT&gt;</code> is the environment variable used. E.g. scimgateway.port could have value &quot;process.env.PORT&quot;, then using environment variable PORT.</li>
 <li>
 <p>All configuration can be set based on corresponding JSON-content in external file using plugin name as parent JSON object (supports also dot notation). Syntax will then be <code>&quot;process.file.&lt;path&gt;&quot;</code> where <code>&lt;path&gt;</code> is the file used. E.g. endpoint.password could have value &quot;process.file./var/run/vault/secrets.json&quot;  
@@ -757,9 +782,11 @@ node c:\my-scimgateway\index.js
 &lt;package-root&gt;node .
 </code></pre>
 
-<p><kbd>Ctrl</kbd>+<kbd>c</kbd> to stop  </p>
+<p><kbd>Ctrl</kbd>+<kbd>c</kbd> to stop  
+</p>
 <h2>Automatic startup - Windows Task Scheduler</h2>
-<p>Start Windows Task Scheduler (taskschd.msc), right click on &quot;Task Scheduler Library&quot; and choose &quot;Create Task&quot;  </p>
+<p>Start Windows Task Scheduler (taskschd.msc), right click on &quot;Task Scheduler Library&quot; and choose &quot;Create Task&quot;  
+</p>
 <pre><code>General tab:  
 -----------
 Name = SCIM Gateway
@@ -783,12 +810,15 @@ Stop the task if runs longer than = Disabled (greyed out)
 
 <p>Verification:</p>
 <ul>
-<li>Right click task - <strong>Run</strong>, verify process node.exe (SCIM Gateway) can be found in the task manager (not the same as task scheduler). Also verify logfiles <code>&lt;pakage-root&gt;\logs</code>  </li>
-<li>Right click task - <strong>End</strong>, verify process node.exe have been terminated and disappeared from task manager   </li>
+<li>Right click task - <strong>Run</strong>, verify process node.exe (SCIM Gateway) can be found in the task manager (not the same as task scheduler). Also verify logfiles <code>&lt;pakage-root&gt;\logs</code>  
+</li>
+<li>Right click task - <strong>End</strong>, verify process node.exe have been terminated and disappeared from task manager   
+</li>
 <li><strong>Reboot</strong> server and verify SCIM Gateway have been automatically started</li>
 </ul>
 <h2>Running as a isolated virtual Docker container</h2>
-<p>On Linux systems we may also run SCIM Gateway as a Docker image (using docker-compose)  </p>
+<p>On Linux systems we may also run SCIM Gateway as a Docker image (using docker-compose)  
+</p>
 <ul>
 <li>
 <p>Docker Pre-requisites:<br />
@@ -859,15 +889,19 @@ ls loki.db
 <code>docker-compose start</code></p>
 <p>To debug running container (using Visual Studio Code):<br />
 <code>docker-compose -f docker-compose.yml -f docker-compose-debug.yml up -d</code><br />
-Start Visual Studio Code and follow <a href="https://code.visualstudio.com/docs/nodejs/nodejs-debugging">these</a> debugging instructions  </p>
-<p>To upgrade scimgateway docker image (remove the old stuff before running docker-compose up --build):  </p>
+Start Visual Studio Code and follow <a href="https://code.visualstudio.com/docs/nodejs/nodejs-debugging">these</a> debugging instructions  
+</p>
+<p>To upgrade scimgateway docker image (remove the old stuff before running docker-compose up --build):  
+</p>
 <pre><code>docker rm scimgateway  
 docker rm $(docker ps -a -q); docker rmi $(docker images -q -f &quot;dangling=true&quot;)  
 </code></pre>
 
 <h2>CA Provisioningserver - SCIM Endpoint</h2>
-<p>Using the CA Provisioning Manager we have to configure  </p>
-<p><code>Endpoint type = SCIM (DYN Endpoint)</code>  </p>
+<p>Using the CA Provisioning Manager we have to configure  
+</p>
+<p><code>Endpoint type = SCIM (DYN Endpoint)</code>  
+</p>
 <p>SCIM endpoint configuration example for Loki plugin (plugin-loki)</p>
 <pre><code>Endpoint Name = Loki  
 User Name = gwadmin  
@@ -880,13 +914,16 @@ or:
 SCIM Based URL = http://localhost:8880/&lt;baseEntity&gt;
 </code></pre>
 
-<p>Username, password and port must correspond with plugin configuration file. For &quot;Loki&quot; plugin it will be <code>config\plugin-loki.json</code>  </p>
+<p>Username, password and port must correspond with plugin configuration file. For &quot;Loki&quot; plugin it will be <code>config\plugin-loki.json</code>  
+</p>
 <p>&quot;SCIM Based URL&quot; refer to the FQDN (or localhost) having SCIM Gateway installed. Portnumber must be included. Use HTTPS instead of HTTP if SCIM Gateway configuration includes certificates. </p>
-<p>&quot;baseEntity&quot; is optional. This is a parameter used for multi tenant or multi endpoint solutions. We could create several endpoints having same base url with unique baseEntity. e.g:  </p>
+<p>&quot;baseEntity&quot; is optional. This is a parameter used for multi tenant or multi endpoint solutions. We could create several endpoints having same base url with unique baseEntity. e.g:  
+</p>
 <p>http://localhost:8880/clientA<br />
 http://localhost:8880/clientB</p>
 <p>Each baseEntity should then be defined in the plugin configuration file with custom attributes needed. Please see examples in plugin-forwardinc.json</p>
-<p>IM 12.6 SP7 (and above) also supports pagination for SCIM endpoint (data transferred in bulks - endpoint explore of users). Loki plugin supports pagination. Other plugin may ignore this setting.  </p>
+<p>IM 12.6 SP7 (and above) also supports pagination for SCIM endpoint (data transferred in bulks - endpoint explore of users). Loki plugin supports pagination. Other plugin may ignore this setting.  
+</p>
 <h2>SCIM Gateway REST API</h2>
 <pre><code>Create = POST http://example.com:8880/Users  
 (body contains the user information)
@@ -911,10 +948,13 @@ GET http://example.com:8880/Schemas
 Introspect resources and attribute extensions.
 </code></pre>
 
-<p>Note:  </p>
+<p>Note:  
+</p>
 <ul>
-<li>userName (mandatory) = UserID  </li>
-<li>id (mandatory) = Unique id. Could be set to the same as UserID but don't have to.  </li>
+<li>userName (mandatory) = UserID  
+</li>
+<li>id (mandatory) = Unique id. Could be set to the same as UserID but don't have to.  
+</li>
 </ul>
 <h2>SAP Hana endpoint</h2>
 <pre><code>Get all users (explore):  
@@ -936,16 +976,19 @@ Modify user (disable user):
 ALTER USER &lt;UserID&gt; DEACTIVATE;  
 </code></pre>
 
-<p>Postinstallation:  </p>
+<p>Postinstallation:  
+</p>
 <pre><code>cd c:\my-scimgateway
 npm install hdb --save  
 </code></pre>
 
 <p>Only SAML users will be explored and managed</p>
-<p>Supported template attributes:  </p>
+<p>Supported template attributes:  
+</p>
 <ul>
 <li>User Name (UserID)</li>
-<li>Suspended (Enabled/Disabled)  </li>
+<li>Suspended (Enabled/Disabled)  
+</li>
 </ul>
 <p>Currently no other attributes needed. Trying to update other attributes will then give an error message.  <strong>The SCIM Provisioning template should therefore not include any other global user attribute references.</strong></p>
 <p>SAP Hana converts UserID to uppercase. Provisioning use default lowercase. Provisioning template should therefore also convert to uppercase.</p>
@@ -953,11 +996,14 @@ npm install hdb --save
 </code></pre>
 
 <h2>Azure Active Directory endpoint</h2>
-<p>Using plugin-azure-ad we could do user provisioning towards Azure AD including license management e.g. O365  </p>
+<p>Using plugin-azure-ad we could do user provisioning towards Azure AD including license management e.g. O365  
+</p>
 <p>For testing purposes we could get an Azure free account and in addition the free Office 365 for testing license management through Azure.</p>
-<p><strong>Azure AD prerequisites</strong>  </p>
+<p><strong>Azure AD prerequisites</strong>  
+</p>
 <ul>
-<li>Logon to <a href="https://portal.azure.com">Azure</a> as global administrator  </li>
+<li>Logon to <a href="https://portal.azure.com">Azure</a> as global administrator  
+</li>
 <li>
 Azure Active Directory - properties
 <ul>
@@ -1011,7 +1057,8 @@ Install the <a href="https://docs.microsoft.com/en-us/powershell/msonline/">Azur
 </ul>
 </li>
 <li>Import-Module MSOnline</li>
-<li>Connect-MsolService (logon as a user having &quot;Global administrator&quot; role)   </li>
+<li>Connect-MsolService (logon as a user having &quot;Global administrator&quot; role)   
+</li>
 <li>
 Get-MsolServicePrincipal -AppPrincipalId {Application ID}  
 
@@ -1057,8 +1104,10 @@ Uncomment startup of plugin-azure-ad, other plugins could be comment out if not 
 
 <p><strong>Edit plugin-azure-ad.json</strong></p>
 <p><code>Username</code> and <code>password</code> used to connect the SCIM Gateway must be defined.</p>
-<p>Update <code>tenantIdGUID</code>, <code>clientID</code> and <code>clientSecret</code> according to Azure AD prerequisites configuration.  </p>
-<p>If using proxy, set proxy.host to <code>&quot;http://&lt;FQDN-ProxyHost&gt;:&lt;port&gt;&quot;</code> e.g <code>&quot;http://proxy.mycompany.com:3128&quot;</code>  </p>
+<p>Update <code>tenantIdGUID</code>, <code>clientID</code> and <code>clientSecret</code> according to Azure AD prerequisites configuration.  
+</p>
+<p>If using proxy, set proxy.host to <code>&quot;http://&lt;FQDN-ProxyHost&gt;:&lt;port&gt;&quot;</code> e.g <code>&quot;http://proxy.mycompany.com:3128&quot;</code>  
+</p>
 <pre><code>&quot;endpoint&quot;: {
   &quot;entity&quot;: {
     &quot;undefined&quot;: {
@@ -1075,7 +1124,8 @@ Uncomment startup of plugin-azure-ad, other plugins could be comment out if not 
 }
 </code></pre>
 
-<p>Note, clientSecret and any proxy.password will become encrypted in this file on the first Azure connection.  </p>
+<p>Note, clientSecret and any proxy.password will become encrypted in this file on the first Azure connection.  
+</p>
 <p>For multi-tenant or multi-endpoint support, we may add several entities:</p>
 <pre><code>&quot;endpoint&quot;: {
   &quot;entity&quot;: {
@@ -1092,9 +1142,12 @@ Uncomment startup of plugin-azure-ad, other plugins could be comment out if not 
 }
 </code></pre>
 
-<p>For additional details, see baseEntity description.  </p>
-<p>Note, we should normally use certificate (https) for communicating with SCIM Gateway unless we install gateway locally on the manager (e.g. on the CA Connector Server). When installed on the manager, we could use <code>http://localhost:port</code> or <code>http://127.0.0.1:port</code> which will not be passed down to the data link layer for transmission. We could then also set {&quot;localhostonly&quot;: true}  </p>
-<p><strong>For CA Provisioning, create endpoint type &quot;Azure - ScimGateway&quot;</strong>  </p>
+<p>For additional details, see baseEntity description.  
+</p>
+<p>Note, we should normally use certificate (https) for communicating with SCIM Gateway unless we install gateway locally on the manager (e.g. on the CA Connector Server). When installed on the manager, we could use <code>http://localhost:port</code> or <code>http://127.0.0.1:port</code> which will not be passed down to the data link layer for transmission. We could then also set {&quot;localhostonly&quot;: true}  
+</p>
+<p><strong>For CA Provisioning, create endpoint type &quot;Azure - ScimGateway&quot;</strong>  
+</p>
 <ul>
 <li>
 Start SCIM Gateway
@@ -1132,8 +1185,10 @@ Right Click &quot;Endpoint Types&quot;, Create New Endpoint Type
 </li>
 </ul>
 <p>Note, metafile &quot;Azure - ScimGateway.xml&quot; is based on CA &quot;Azure - WSL7&quot; with some minor adjustments like using Microsoft Graph API attributes instead of Azure AD Graph attributes.</p>
-<p><strong>Using the CA Provisioning Manager we have to configure</strong>  </p>
-<p><code>Endpoint type = Azure - ScimGateway (DYN Endpoint)</code>  </p>
+<p><strong>Using the CA Provisioning Manager we have to configure</strong>  
+</p>
+<p><code>Endpoint type = Azure - ScimGateway (DYN Endpoint)</code>  
+</p>
 <p>Endpoint configuration example:</p>
 <pre><code>Endpoint Name = Azure-AD-8881  
 User Name = gwadmin  
@@ -1147,9 +1202,13 @@ SCIM Based URL = http://localhost:8881/&lt;baseEntity&gt;
 <p>For details, please see section &quot;CA Provisioningserver - SCIM Endpoint&quot;</p>
 <h2>Azure Active Directory using SCIM Gateway</h2>
 <p>Azure AD could do automatic user provisioning by synchronizing users towards SCIM Gateway, and gateway plugins will update endpoints.</p>
-<p>Plugin configuration file must include scimversion &quot;2.0&quot; and either bearer.token or azure.tenantIdGUID (or both):  </p>
+<p>Plugin configuration file must include SCIM Version 2.0 (<code>scim.version</code>) and either Bearer Token (<code>auth.bearer.token</code>) or Azure Tenant ID GUID (<code>auth.bearer.jwt.azure.tenantIdGUID</code>) or both:
+</p>
 <pre><code>{
-  &quot;scimversion&quot;: &quot;2.0&quot;,
+  &quot;scim&quot;: {
+    &quot;version&quot;: &quot;2.0&quot;,
+    ...
+  },
   ...
   &quot;auth&quot;: {
     ...
@@ -1166,14 +1225,17 @@ SCIM Based URL = http://localhost:8881/&lt;baseEntity&gt;
 </code></pre>
 
 <p><code>bearer.token</code> configuration must correspond with &quot;Secret Token&quot; defined in Azure AD<br />
-<code>tenantIdGUID</code> configuration must correspond with Azure Active Directory Tenant ID  </p>
+<code>tenantIdGUID</code> configuration must correspond with Azure Active Directory Tenant ID  
+</p>
 <p>In Azure Portal:
 <code>Azure-Azure Active Directory-Enterprise Application-&lt;My Application&gt;-Provisioning-Secret Token</code><br />
 Note, when &quot;Secret Token&quot; is left blank, Azure will use JWT (tenantIdGUID)</p>
 <p><code>Azure-Azure Active Directory-Properties-Directory ID</code></p>
-<p>User mappings attributes between AD and SCIM also needs to be configured  </p>
+<p>User mappings attributes between AD and SCIM also needs to be configured  
+</p>
 <p><code>Azure-Azure Active Directory-Enterprise Application-&lt;My Application&gt;-Provisioning-Mappings</code></p>
-<p>Azure AD default SCIM attribute mapping for <strong>USER</strong> have:  </p>
+<p>Azure AD default SCIM attribute mapping for <strong>USER</strong> have:  
+</p>
 <pre><code>externalId mapped to mailNickname (matching precedence #1)  
 userName mapped to userPrincipalName  
 </code></pre>
@@ -1188,17 +1250,20 @@ externalId mapped to userPrincipalName (matching precedence #1)
 userName mapped to userPrincipalName  
 </code></pre>
 
-<p>Azure AD default SCIM attribute mapping for <strong>GROUP</strong> have:  </p>
+<p>Azure AD default SCIM attribute mapping for <strong>GROUP</strong> have:  
+</p>
 <pre><code>externalId mapped to displayName (matching precedence #1)  
 displayName mapped to mailNickname  
 </code></pre>
 
-<p>SCIM Gateway accepts externalId (as matching precedence) instead of displayName, but <code>displayName and externalId must then be mapped to the same AD attribute</code> e.g:  </p>
+<p>SCIM Gateway accepts externalId (as matching precedence) instead of displayName, but <code>displayName and externalId must then be mapped to the same AD attribute</code> e.g:  
+</p>
 <pre><code>externalId mapped to displayName (matching precedence #1)
 displayName mapped to displayName
 </code></pre>
 
-<p>Some notes related to Azure AD:  </p>
+<p>Some notes related to Azure AD:  
+</p>
 <ul>
 <li>
 <p>Azure Active Directory SCIM <a href="https://docs.microsoft.com/en-us/azure/active-directory/active-directory-scim-provisioning">documentation</a>  
@@ -1220,7 +1285,8 @@ displayName mapped to displayName
 </li>
 </ul>
 <h2>api-plugin</h2>
-<p>SCIM Gateway supports following methods for the none SCIM based api-plugin:  </p>
+<p>SCIM Gateway supports following methods for the none SCIM based api-plugin:  
+</p>
 <pre><code>    GET /api  
     GET /api?queries  
     GET /api/{id}  
@@ -1235,12 +1301,16 @@ displayName mapped to displayName
 <p>Preparation:</p>
 <ul>
 <li>Copy &quot;best matching&quot; example plugin e.g. <code>lib\plugin-loki.js</code> and <code>config\plugin-loki.json</code> and rename both copies to your plugin name prefix e.g. plugin-mine.js and plugin-mine.json (for SOAP Webservice endpoint we might use plugin-forwardinc as a template) </li>
-<li>Edit plugin-mine.json and define a unique port number for the gateway setting  </li>
-<li>Edit index.js and add a new line for starting your plugin e.g. <code>let mine = require('./lib/plugin-mine');</code>  </li>
-<li>Start SCIM Gateway and verify. If using CA Provisioning you could setup a SCIM endpoint using the port number you defined  </li>
+<li>Edit plugin-mine.json and define a unique port number for the gateway setting  
+</li>
+<li>Edit index.js and add a new line for starting your plugin e.g. <code>let mine = require('./lib/plugin-mine');</code>  
+</li>
+<li>Start SCIM Gateway and verify. If using CA Provisioning you could setup a SCIM endpoint using the port number you defined  
+</li>
 </ul>
 <p>Now we are ready for custom coding by editing plugin-mine.js
-Coding should be done step by step and each step should be verified and tested before starting the next (they are all highlighted by comments in existing code).  </p>
+Coding should be done step by step and each step should be verified and tested before starting the next (they are all highlighted by comments in existing code).  
+</p>
 <ol>
 <li><strong>Turn off group functionality</strong> in getGroup, getGroupMembers, getGroupUsers and modifyGroupMembers<br />
 Please see callback definitions in plugin-saphana that do not use groups.</li>
@@ -1254,16 +1324,23 @@ Please see callback definitions in plugin-saphana that do not use groups.</li>
 <li><strong>getGroup</strong> (test provisioning group list groups)</li>
 <li><strong>getGroupMembers</strong> (test provisioning retrieve account - group list groups)</li>
 <li><strong>modifyGroupMembers</strong> (test provisioning retrieve account - group add/remove groups)</li>
-<li><strong>getGroupUsers</strong> (if using &quot;groups member of user&quot;)   </li>
-<li><strong>createGroup</strong> (test provisioning new group)  </li>
+<li><strong>getGroupUsers</strong> (if using &quot;groups member of user&quot;)   
+</li>
+<li><strong>createGroup</strong> (test provisioning new group)  
+</li>
 </ol>
-<p>Template used by CA Provisioning role should only include endpoint supported attributes defined in our plugin. Template should therefore have no links to global user for none supported attributes (e.g. remove %UT% from &quot;Job Title&quot; if our endpoint/code do not support title)  </p>
-<p>CA Provisioning using default SCIM endpoint do not support SCIM Enterprise User Schema Extension (having attributes like employeeNumber, costCenter, organization, division, department and manager). If we need these or other attributes not found in CA Provisioning, we could define our own by using the free-text &quot;type&quot; definition in the multivalue entitlements or roles attribute. In the template entitlements definition, we could for example define type=Company and set value to %UCOMP%. Please see plugin-forwardinc.js using Company as a multivalue &quot;type&quot; definition.  </p>
+<p>Template used by CA Provisioning role should only include endpoint supported attributes defined in our plugin. Template should therefore have no links to global user for none supported attributes (e.g. remove %UT% from &quot;Job Title&quot; if our endpoint/code do not support title)  
+</p>
+<p>CA Provisioning using default SCIM endpoint do not support SCIM Enterprise User Schema Extension (having attributes like employeeNumber, costCenter, organization, division, department and manager). If we need these or other attributes not found in CA Provisioning, we could define our own by using the free-text &quot;type&quot; definition in the multivalue entitlements or roles attribute. In the template entitlements definition, we could for example define type=Company and set value to %UCOMP%. Please see plugin-forwardinc.js using Company as a multivalue &quot;type&quot; definition.  
+</p>
 <p>Using CA Connector Xpress we could create a new SCIM endpoint type based on the original SCIM. We could then add/remove attributes and change from default assign &quot;user to groups&quot; to assign &quot;groups to user&quot;. There are also other predefined endpoints based on the original SCIM. You may take a look at &quot;ServiceNow - WSL7&quot; and &quot;Zendesk - WSL7&quot;. </p>
-<p>For project setup:  </p>
+<p>For project setup:  
+</p>
 <ul>
-<li>Datasource =  Layer7 (CA API) - this is SCIM  </li>
-<li>Layer7 Base URL = SCIM Gateway url and port (SCIM Base URL)  </li>
+<li>Datasource =  Layer7 (CA API) - this is SCIM  
+</li>
+<li>Layer7 Base URL = SCIM Gateway url and port (SCIM Base URL)  
+</li>
 <li>Authentication = Basic Authentication<br />
 (connect using gwadmin/password defined in plugin config-file)</li>
 </ul>
@@ -1281,14 +1358,17 @@ User Account - Accociations - with Group</p>
 <p>User Attribute = <strong>Physical Attribute = Groups</strong><br />
 Match Group = By Attribute = Name</p>
 <p>Objects Must Exist<br />
-Use DNs in Attribute = deactivated (toggled off)  </p>
+Use DNs in Attribute = deactivated (toggled off)  
+</p>
 <p>Include a Reverse Association (if needed)<br />
 Group Attribute = <strong>Virtual Attribute = User Membership</strong><br />
-Match User Account = By Attribute = User Name  </p>
+Match User Account = By Attribute = User Name  
+</p>
 <p>Note, groups should be capability attribute (updated when account is synchronized with template):<br />
 advanced options - <strong>Synchronized</strong> = enabled (toggled on)</p>
 <h2>Methods</h2>
-<p>Plugins should have following initialization:  </p>
+<p>Plugins should have following initialization:  
+</p>
 <pre><code>// mandatory plugin initialization - start
 const path = require('path')
 let ScimGateway = null
@@ -1320,9 +1400,12 @@ config = scimgateway.processExtConfig(pluginName, config)
 </code></pre>
 
 <ul>
-<li>baseEntity = Optional for multi-tenant or multi-endpoint support (defined in base url e.g. <code>&lt;baseurl&gt;/client1</code> gives baseEntity=client1)  </li>
-<li>startIndex = Pagination - The 1-based index of the first result in the current set of search results  </li>
-<li>count = Pagination - Number of elements to be returned in the current set of search results  </li>
+<li>baseEntity = Optional for multi-tenant or multi-endpoint support (defined in base url e.g. <code>&lt;baseurl&gt;/client1</code> gives baseEntity=client1)  
+</li>
+<li>startIndex = Pagination - The 1-based index of the first result in the current set of search results  
+</li>
+<li>count = Pagination - Number of elements to be returned in the current set of search results  
+</li>
 <li>ret: <br />
 ret.Resources = array filled with objects containing userName and id (userName and id set to the same value) e.g [{&quot;userName&quot;:&quot;bjensen&quot;,&quot;id&quot;:&quot;bjensen&quot;}, &quot;userName&quot;:&quot;jsmith&quot;,&quot;id&quot;:&quot;jsmith&quot;}]<br />
 ret.totalResults = if supporting pagination, then attribute should be set to the total numbers of elements (users) at the endpoint, else set to null</li>
@@ -1351,8 +1434,10 @@ ret.totalResults = if supporting pagination attribute should be set to the total
 </code></pre>
 
 <ul>
-<li>userName = user id (eg. bjensen)  </li>
-<li>attributes = scim attributes to be returned. If no attributes defined, all should be returned.  </li>
+<li>userName = user id (eg. bjensen)  
+</li>
+<li>attributes = scim attributes to be returned. If no attributes defined, all should be returned.  
+</li>
 <li>return userObj: userObj containing scim userattributes/values
 eg:<br />
 {&quot;id&quot;:&quot;bjensen&quot;,&quot;name&quot;:{&quot;formatted&quot;:&quot;Ms. Barbara J Jensen III&quot;,&quot;familyName&quot;:&quot;Jensen&quot;,&quot;givenName&quot;:&quot;Barbara&quot;}}</li>
@@ -1369,8 +1454,10 @@ eg:<br />
 
 <ul>
 <li>userObj = user object containing userattributes according to scim standard<br />
-Note, multi-value attributes excluding user attribute 'groups' are customized from array to object based on type  </li>
-<li>return null: null if OK, else throw error  </li>
+Note, multi-value attributes excluding user attribute 'groups' are customized from array to object based on type  
+</li>
+<li>return null: null if OK, else throw error  
+</li>
 </ul>
 <h3>deleteUser</h3>
 <pre><code>scimgateway.deleteUser = async (baseEntity, id) =&gt; {
@@ -1381,7 +1468,8 @@ Note, multi-value attributes excluding user attribute 'groups' are customized fr
 
 <ul>
 <li>id = user id to be deleted </li>
-<li>return null: null if OK, else throw error  </li>
+<li>return null: null if OK, else throw error  
+</li>
 </ul>
 <h3>modifyUser</h3>
 <pre><code>scimgateway.modifyUser = async (baseEntity, id, attrObj) =&gt; {
@@ -1391,9 +1479,11 @@ Note, multi-value attributes excluding user attribute 'groups' are customized fr
 </code></pre>
 
 <ul>
-<li>id = user id  </li>
+<li>id = user id  
+</li>
 <li>attrObj = object containing userattributes to be modified according to scim standard<br />
-Note, multi-value attributes excluding user attribute 'groups' are customized from array to object based on type  </li>
+Note, multi-value attributes excluding user attribute 'groups' are customized from array to object based on type  
+</li>
 <li>return null: null if OK, else throw error</li>
 </ul>
 <h3>getGroup</h3>
@@ -1404,8 +1494,10 @@ Note, multi-value attributes excluding user attribute 'groups' are customized fr
 </code></pre>
 
 <ul>
-<li>displayName = group name  </li>
-<li>attributes  = scim attributes to be returned in callback (displayName and members is mandatory)  </li>
+<li>displayName = group name  
+</li>
+<li>attributes  = scim attributes to be returned in callback (displayName and members is mandatory)  
+</li>
 <li>
 <p>return retObj: retObj containing group displayName and id (+ members if using default &quot;users are member of group&quot;)  
 </p>
@@ -1425,12 +1517,17 @@ Note, multi-value attributes excluding user attribute 'groups' are customized fr
 }
 </code></pre>
 
-<p>Retrieve all users for a spesific group WHEN <strong>&quot;user member of group&quot;</strong>. This setting is CA IM default scim endpoint configuration. This means Group having multivalue attribute members containing userName.  </p>
+<p>Retrieve all users for a spesific group WHEN <strong>&quot;user member of group&quot;</strong>. This setting is CA IM default scim endpoint configuration. This means Group having multivalue attribute members containing userName.  
+</p>
 <ul>
-<li>id = user id (eg. bjensen)  </li>
-<li>attributes = attributes to be returned in callback (we only return the name of groups - displayName and current user as member)  </li>
-<li>startIndex = Pagination - The 1-based index of the first result in the current set of search results  </li>
-<li>count = Pagination - Number of elements to be returned in the current set of search results  </li>
+<li>id = user id (eg. bjensen)  
+</li>
+<li>attributes = attributes to be returned in callback (we only return the name of groups - displayName and current user as member)  
+</li>
+<li>startIndex = Pagination - The 1-based index of the first result in the current set of search results  
+</li>
+<li>count = Pagination - Number of elements to be returned in the current set of search results  
+</li>
 <li>
 <p>return ret:<br />
 ret.Resources = array to be filled with objects containing groups with current user as member<br />
@@ -1450,10 +1547,13 @@ e.g [{&quot;displayName&quot;:&quot;Admins&quot;,&quot;members&quot;: [{ &quot;v
 }
 </code></pre>
 
-<p>Retrieve all users for a spesific group WHEN <strong>&quot;group member of user&quot;</strong>. This means user having multivalue attribute groups containing value GroupName  </p>
+<p>Retrieve all users for a spesific group WHEN <strong>&quot;group member of user&quot;</strong>. This means user having multivalue attribute groups containing value GroupName  
+</p>
 <ul>
-<li>groupName = group name (eg. UserGroup-1)  </li>
-<li>attributes = scim attributes to be returned in callback  </li>
+<li>groupName = group name (eg. UserGroup-1)  
+</li>
+<li>attributes = scim attributes to be returned in callback  
+</li>
 <li>
 <p>return arrRet: arrRet = array containing the userName's'
 e.g: [{&quot;userName&quot;, &quot;bjensen&quot;}, {&quot;userName&quot;, &quot;jsmith&quot;}]</p>
@@ -1471,7 +1571,8 @@ e.g: [{&quot;userName&quot;, &quot;bjensen&quot;}, {&quot;userName&quot;, &quot;
 <ul>
 <li>groupObj = group object containing groupattributes according to scim standard<br />
 groupObj.displayName contains the group name to be created</li>
-<li>return null: null if OK, else throw error  </li>
+<li>return null: null if OK, else throw error  
+</li>
 </ul>
 <h3>deleteGroup</h3>
 <pre><code>scimgateway.deleteGroup = async (baseEntity, id) =&gt; {
@@ -1492,12 +1593,15 @@ groupObj.displayName contains the group name to be created</li>
 </code></pre>
 
 <ul>
-<li>id = group name (eg. Admins)  </li>
+<li>id = group name (eg. Admins)  
+</li>
 <li>members = array of objects containing groupmembers modifications<br />
 eg: {&quot;value&quot;:&quot;bjensen&quot;},{&quot;operation&quot;:&quot;delete&quot;,&quot;value&quot;:&quot;jsmith&quot;}<br />
-(adding bjensen and deliting jsmith from group)  </li>
+(adding bjensen and deliting jsmith from group)  
+</li>
 <li>return null: null if OK, else throw error<br />
-If we do not support groups, then return null  </li>
+If we do not support groups, then return null  
+</li>
 </ul>
 <h2>Known limitations</h2>
 <ul>
@@ -1521,17 +1625,21 @@ If we do not support groups, then return null  </li>
 <li>Colorize option now automatically turned off when using stdout/stderr redirect (configuration file <code>loglevel.colorize</code> is not needed)</li>
 </ul>
 <h3>v2.1.2</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>SCIM 2.0 may use Operations.value as array and none array (issue #16) </li>
 </ul>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Option for replacing mandatory userName/displayName attribute by configuring customUniqueAttrMapping  </li>
+<li>Option for replacing mandatory userName/displayName attribute by configuring customUniqueAttrMapping  
+</li>
 <li>Includes latest versions of module dependencies</li>
 </ul>
 <h3>v2.1.1</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>SCIM 2.0 may use Operations.value or Operation.value[] for PATCH syntax of the name object (issue #14)</li>
 <li>plugin-loki failed to modify a none existing object, e.g name object not included in Create User </li>
@@ -1541,7 +1649,8 @@ If we do not support groups, then return null  </li>
 <ul>
 <li>Custom schema attributes can be added by plugin configuration <code>scim.customSchema</code> having value set to filename of a JSON schema-file located in <code>&lt;package-root&gt;/config/schemas</code></li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>
 <p>Configurationfiles for custom plugins should be changed<br />
@@ -1562,58 +1671,78 @@ If we do not support groups, then return null  </li>
 </li>
 </ul>
 <h3>v2.0.2</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>SCIM 2.0 incorrect response for user not found</li>
 <li>Did not mask logentries ending with newline</li>
 </ul>
 <h3>v2.0.0</h3>
-<p><strong>[MAJOR]</strong>  </p>
+<p><strong>[MAJOR]</strong>  
+</p>
 <ul>
-<li>Codebase moved from callback to async/await  </li>
-<li>Koa replacing Express  </li>
-<li>Some log enhancements  </li>
-<li>Deprecated cipher methods have been replaced  </li>
+<li>Codebase moved from callback to async/await  
+</li>
+<li>Koa replacing Express  
+</li>
+<li>Some log enhancements  
+</li>
+<li>Deprecated cipher methods have been replaced  
+</li>
 <li>Plugin restful (REST) and forwardinc (SOAP) includes failover logic based on endpoints defined in array baseUrls/baseServiceEndpoints. </li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
-<p>Note, this is a major upgrade (^1.x.x =&gt; ^2.x.x) and will brake compatibility with any existing custom plugins. To force a major upgrade, suffix <code>@latest</code> must be include in the npm install command, but it's recommended to do a fresh install and copy any custom plugins instead of upgrading an existing package  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
+<p>Note, this is a major upgrade (^1.x.x =&gt; ^2.x.x) and will brake compatibility with any existing custom plugins. To force a major upgrade, suffix <code>@latest</code> must be include in the npm install command, but it's recommended to do a fresh install and copy any custom plugins instead of upgrading an existing package  
+</p>
 <pre><code>cd c:\my-scimgateway
 npm install scimgateway@latest
 </code></pre>
 
-<p>Custom plugins needs some changes (please see included example plugins)  </p>
+<p>Custom plugins needs some changes (please see included example plugins)  
+</p>
 <ul>
 <li><code>scimgateway.on(xxx, function (..., callback)</code> replaced with <code>scimgateway.xxx = async (...)</code> returning a result or throwing an error</li>
-<li>Rest and SOAP using <code>doRequest</code> method having endpoint failover logic through array <code>baseUrls/baseServiceEndpoints</code> defined in corresponding plugin configuration file.  </li>
+<li>Rest and SOAP using <code>doRequest</code> method having endpoint failover logic through array <code>baseUrls/baseServiceEndpoints</code> defined in corresponding plugin configuration file.  
+</li>
 <li>Additional argument <code>attributes</code> included in exploreUsers and exploreGroups method</li>
-<li>Proxy configuration includes option for user/password  </li>
-<li>Encrypted passwords in configuration files needs to be reset to clear text passwords  </li>
+<li>Proxy configuration includes option for user/password  
+</li>
+<li>Encrypted passwords in configuration files needs to be reset to clear text passwords  
+</li>
 </ul>
 <h3>v1.0.20</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>HTTP status code 200 and totalResults set to value of 0 when using SCIM 2.0 filter user/group and no resulted user/group found. SCIM 1.1 still using  status code 404.</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
-<li>For custom plugins to be compliant with SCIM 2.0, the <code>getUser</code> and <code>getGroup</code> methods needs to be updated. If user/group not found then return <code>callback(null, null)</code> instead of callback(err)  </li>
+<li>For custom plugins to be compliant with SCIM 2.0, the <code>getUser</code> and <code>getGroup</code> methods needs to be updated. If user/group not found then return <code>callback(null, null)</code> instead of callback(err)  
+</li>
 </ul>
 <h3>v1.0.19</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Fix related to external configuration (ref. v1.0.18) when running multiple plugins  </li>
+<li>Fix related to external configuration (ref. v1.0.18) when running multiple plugins  
+</li>
 </ul>
 <h3>v1.0.18</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Includes latest versions of module dependencies</li>
 <li>Loglevel configuration for file and console now separated</li>
-<li>Loglevel colorize option (value false could be useful when redirecting console output)  </li>
+<li>Loglevel colorize option (value false could be useful when redirecting console output)  
+</li>
 <li>All configuration can be set based on environment variables</li>
 <li>All configuration can be set based on correspondig json-content in external file (supports also dot notation)</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>
 <p>Configurationfiles for custom plugins should be changed<br />
@@ -1634,97 +1763,128 @@ npm install scimgateway@latest
 </li>
 </ul>
 <h3>v1.0.14</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Some multiValued attributes not correctly handled (e.g. addresses)  </li>
+<li>Some multiValued attributes not correctly handled (e.g. addresses)  
+</li>
 </ul>
 <h3>v1.0.13</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>plugin-azure-ad: New version of &quot;Azure - ScimGateway.xml&quot; fixing CA IM RoleDefGenerator problem (related to creating and importing screens in CA IM)  </li>
+<li>plugin-azure-ad: New version of &quot;Azure - ScimGateway.xml&quot; fixing CA IM RoleDefGenerator problem (related to creating and importing screens in CA IM)  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Use CA ConnectorXpress, import &quot;Azure - ScimGateway.xml&quot; and deploy/redeploy endpoint</li>
 </ul>
 <h3>v1.0.12</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Incorrect logging of Express stream messages (type info) when running multiple plugins    </li>
+<li>Incorrect logging of Express stream messages (type info) when running multiple plugins    
+</li>
 </ul>
 <h3>v1.0.11</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>plugin-azure-ad: proxy configuration did not work    </li>
+<li>plugin-azure-ad: proxy configuration did not work    
+</li>
 </ul>
 <h3>v1.0.10</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>An issue with pagination fixed  </li>
+<li>An issue with pagination fixed  
+</li>
 </ul>
 <h3>v1.0.9</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Cosmetics, changed emailOnError logic - now emitted by logger</li>
 </ul>
 <h3>v1.0.8</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Support health monitoring using the &quot;/ping&quot; URL with a &quot;hello&quot; response, e.g. http://localhost:8880/ping. Useful for frontend load balancing/failover functionality  </li>
-<li>Option for error notifications by email  </li>
+<li>Support health monitoring using the &quot;/ping&quot; URL with a &quot;hello&quot; response, e.g. http://localhost:8880/ping. Useful for frontend load balancing/failover functionality  
+</li>
+<li>Option for error notifications by email  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Configuration files for custom plugins must include the <strong>emailOnError</strong> object for enabling error notifications by email. Please see the syntax in provided example plugins and details described in the &quot;Configuration&quot; section of this document.</li>
 </ul>
 <h3>v1.0.7</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Docker now using node v.9.10.0 instead of v.6.9.2</li>
 <li>Minor log cosmetics</li>
 </ul>
 <h3>v1.0.6</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Azure AD plugin, failed to create user when licenses (app Service plans) was included  </li>
+<li>Azure AD plugin, failed to create user when licenses (app Service plans) was included  
+</li>
 </ul>
 <h3>v1.0.5</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Supporting GET /Users, GET /Groups, PUT method and delete groups  </li>
+<li>Supporting GET /Users, GET /Groups, PUT method and delete groups  
+</li>
 <li>After more than 3 invalid auth attempts, response will be delayed to prevent brute force</li>
 </ul>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Some minor compliance fixes  </li>
+<li>Some minor compliance fixes  
+</li>
 </ul>
 <p><strong>Thanks to ywchuang</strong> </p>
 <h3>v1.0.4</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Plugin for Azure AD now supports paging for retrieving users and groups. Any existing metafile used by CA ConnectorXpress (&quot;Azure - ScimGateway.xml&quot;) must be re-deployed.</li>
 </ul>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Don't use deprecated existsSync in postinstallation </li>
 </ul>
 <h3>v1.0.3</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Undefined root url not handled correctly after v1.0.0</li>
 </ul>
 <h3>v1.0.2</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>License and group defined as capability attributes in metafile used by CA ConnectorXpress regarding plugin-azure-ad     </li>
+<li>License and group defined as capability attributes in metafile used by CA ConnectorXpress regarding plugin-azure-ad     
+</li>
 </ul>
 <h3>v1.0.1</h3>
-<p>[FIX]  </p>
+<p>[FIX]  
+</p>
 <ul>
-<li>Mocha test script did not terminate after upgrading from 3.x to 4.x of Mocha  </li>
+<li>Mocha test script did not terminate after upgrading from 3.x to 4.x of Mocha  
+</li>
 </ul>
 <h3>v1.0.0</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>New plugin-azure-ad.js for Azure AD user provisioning including Azure license management e.g. Office 365</li>
 <li>Includes latest versions of module dependencies</li>
@@ -1732,7 +1892,8 @@ npm install scimgateway@latest
 </ul>
 <p><strong>[UPGRADE]</strong><br />
 Method <code>getGroupMembers</code> must be updated for all custom plugins</p>
-<p>Replace:  </p>
+<p>Replace:  
+</p>
 <pre><code>scimgateway.on('getGroupMembers', function (baseEntity, id, attributes, startIndex, count, callback) {
 ...
 let ret = {
@@ -1745,7 +1906,8 @@ ret.Resources.push(userGroup)
 callback(null, ret)
 </code></pre>
 
-<p>With:  </p>
+<p>With:  
+</p>
 <pre><code>scimgateway.on('getGroupMembers', function (baseEntity ,id ,attributes, callback) {
 ...
 let arrRet = []
@@ -1756,7 +1918,8 @@ callback(null, arrRet)
 </code></pre>
 
 <h3>v0.5.3</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>
 Includes api gateway/plugin for general none provisioning  
@@ -1774,7 +1937,8 @@ Includes api gateway/plugin for general none provisioning
 <li>plugin-api.js demonstrates api functionallity (becomes what you want it to become) </li>
 </ul>
 <h3>v0.5.2</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>
 One or more of following authentication/authorization methods are accepted:  
@@ -1787,7 +1951,8 @@ One or more of following authentication/authorization methods are accepted:
 </ul>
 </li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>
 Configuration files for custom plugins <code>config/plugin-xxx.json</code> needs to be updated regarding the new <code>scimgateway.auth</code> section:  
@@ -1804,20 +1969,27 @@ Configuration files for custom plugins <code>config/plugin-xxx.json</code> needs
 </li>
 </ul>
 <h3>v0.4.6</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Document updated on how to run SCIM Gateway as a Docker container  </li>
+<li>Document updated on how to run SCIM Gateway as a Docker container  
+</li>
 <li><code>config\docker</code> includes docker configuration examples<br />
-<strong>Thanks to Charley Watson and Jeffrey Gilbert</strong>  </li>
+<strong>Thanks to Charley Watson and Jeffrey Gilbert</strong>  
+</li>
 </ul>
 <h3>v0.4.5</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Environment variable <code>SEED</code> overrides default password seeding  </li>
-<li>Setting SCIM Gateway port to <code>&quot;process.env.XXX&quot;</code> lets environment variable XXX define the port  </li>
+<li>Environment variable <code>SEED</code> overrides default password seeding  
+</li>
+<li>Setting SCIM Gateway port to <code>&quot;process.env.XXX&quot;</code> lets environment variable XXX define the port  
+</li>
 <li>Don't validate config-file port number for numeric value (Azure AD - iisnode using a name pipe for communication) </li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>
 Configuration files for custom plugins <code>config/plugin-xxx.json</code> needs to be updated:  
@@ -1830,111 +2002,147 @@ Configuration files for custom plugins <code>config/plugin-xxx.json</code> needs
 </li>
 </ul>
 <h3>v0.4.4</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>NoSQL Document-Oriented Database plugin: <code>plugin-loki</code><br />
 This plugin now replace previous <code>plugin-testmode</code><br />
-<strong>Thanks to Jeffrey Gilbert</strong>  </li>
-<li>Minor code/comment reorganizations in provided plugins  </li>
-<li>Minor adjustments to multi-value logic introduced in v0.4.0  </li>
+<strong>Thanks to Jeffrey Gilbert</strong>  
+</li>
+<li>Minor code/comment reorganizations in provided plugins  
+</li>
+<li>Minor adjustments to multi-value logic introduced in v0.4.0  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Delete depricated <code>lib/plugin-testmode.js</code> and <code>config/plugin-testmode.json</code></li>
-<li>Edit index.js, replace tesmode with loki   </li>
+<li>Edit index.js, replace tesmode with loki   
+</li>
 </ul>
 <h3>v0.4.2</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>plugin-restful minor adjustments to multivalue and cleared attributes logic introduced in v0.4.0  </li>
+<li>plugin-restful minor adjustments to multivalue and cleared attributes logic introduced in v0.4.0  
+</li>
 </ul>
 <h3>v0.4.1</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
-<li>Mocha test scripts for automated testing of plugin-testmode  </li>
+<li>Mocha test scripts for automated testing of plugin-testmode  
+</li>
 <li>Automated tests run on Travis-ci.org (click on build badge) </li>
 <li><strong>Thanks to Jeffrey Gilbert</strong></li>
 </ul>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Minor adjustments to multi-value logic introduced in v0.4.0</li>
 </ul>
 <h3>v0.4.0</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Not using the SCIM standard for handling multivalue attributes and cleared attributes. Changed from array to object based on type. This simplifies plugin-coding for multivalue attributes like emails, phoneNumbers, entitlements, ...</li>
-<li>Module dependencies updated to latest versions  </li>
+<li>Module dependencies updated to latest versions  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Custom plugins using multivalue attributes needs to be updated regarding methods createUser and modifyUser. Please see example plugins for details.</li>
 </ul>
 <h3>v0.3.8</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Minor changes related to SCIM specification</li>
 </ul>
 <h3>v0.3.7</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>PFX / PKCS#12 certificate bundle is supported</li>
 </ul>
 <h3>v0.3.6</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>SCIM Gateway used by Microsoft Azure Active Directory is supported</li>
 <li>SCIM version 2.0 is supported</li>
-<li>Create group is supported  </li>
+<li>Create group is supported  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>For custom plugins to support create group, they needs to be updated regarding listener method <code>scimgateway.on('createGroup',...</code> Please see example plugins for details. </li>
 </ul>
 <h3>v0.3.5</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>plugin-mssql not included in postinstall  </li>
+<li>plugin-mssql not included in postinstall  
+</li>
 </ul>
 <h3>v0.3.4</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>MSSQL example plugin: <code>plugin-mssql</code> </li>
-<li>Changed multivalue logic in example plugins, now using <code>scimgateway.getArrayObject</code>  </li>
+<li>Changed multivalue logic in example plugins, now using <code>scimgateway.getArrayObject</code>  
+</li>
 </ul>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Minor changes related to SCIM specification</li>
 </ul>
 <h3>v0.3.3</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
-<li>Logic for handling incorrect pagination request to avoid endless loop conditions (there is a pagination bug in CA Identity Manager v.14)  </li>
-<li>Pagination now supported on getGroupMembers  </li>
+<li>Logic for handling incorrect pagination request to avoid endless loop conditions (there is a pagination bug in CA Identity Manager v.14)  
+</li>
+<li>Pagination now supported on getGroupMembers  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Custom plugins needs to be updated regarding listener method <code>scimgateway.on('getGroupMembers',...</code> New arguments have been added &quot;startIndex&quot; and &quot;count&quot;. Also a new return variable &quot;ret&quot;. Please see example plugins for details.</li>
 </ul>
 <h3>v0.3.2</h3>
-<p>[Fix]  </p>
+<p>[Fix]  
+</p>
 <ul>
 <li>Minor changes related to SCIM specification</li>
 </ul>
 <h3>v0.3.1</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>REST Webservices example plugin: <code>plugin-restful</code> </li>
 </ul>
 <h3>v0.3.0</h3>
-<p>[ENHANCEMENT]  </p>
+<p>[ENHANCEMENT]  
+</p>
 <ul>
 <li>Preferred installation method changed from &quot;global&quot; to &quot;local&quot;</li>
-<li><code>&lt;Base URL&gt;/[baseEntity]</code> for multi tenant or multi endpoint flexibility  </li>
-<li>plugin-forwardinc includes examples of baseEntity, custom soap header and signed saml assertion  </li>
-<li>Support groups defined on user object &quot;group member of user&quot;  </li>
-<li>New module dependendcies included: saml, async and callsite  </li>
+<li><code>&lt;Base URL&gt;/[baseEntity]</code> for multi tenant or multi endpoint flexibility  
+</li>
+<li>plugin-forwardinc includes examples of baseEntity, custom soap header and signed saml assertion  
+</li>
+<li>Support groups defined on user object &quot;group member of user&quot;  
+</li>
+<li>New module dependendcies included: saml, async and callsite  
+</li>
 </ul>
-<p><strong>[UPGRADE]</strong>  </p>
+<p><strong>[UPGRADE]</strong>  
+</p>
 <ul>
 <li>Use &quot;fresh&quot; install and restore any custom plugins. Custom plugins needs to be updated. Listener method names have changed and method must include &quot;baseEntity&quot; - please see example plugins.</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -788,10 +788,13 @@ For details, please see section "CA Provisioningserver - SCIM Endpoint"
 
 Azure AD could do automatic user provisioning by synchronizing users towards SCIM Gateway, and gateway plugins will update endpoints.
 
-Plugin configuration file must include scimversion "2.0" and either bearer.token or azure.tenantIdGUID (or both):  
+Plugin configuration file must include SCIM Version 2.0 (_scim.version_)  and either Bearer Token (_auth.bearer.token_) or Azure Tenant ID GUID (_auth.bearer.jwt.azure.tenantIdGUID_) or both:  
 
 	{
-	  "scimversion": "2.0",
+	  "scim": {
+	    "version": "2.0",
+	    ...
+	  },
 	  ...
 	  "auth": {
 	    ...

--- a/config/plugin-loki.json
+++ b/config/plugin-loki.json
@@ -3,7 +3,7 @@
     "port": 8880,
     "localhostonly": false,
     "scim": {
-      "version": "1.1",
+      "version": "2.0",
       "customSchema": null,
       "customUniqueAttrMapping" : {
         "userName" : null,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,11 @@
+class DuplicateKeyError extends Error {
+  constructor(message, originalError) {
+    super(message);
+    this.originalError = originalError;
+    this.statusCode = 409; // 409 Conflict
+  }
+}
+
+module.exports = {
+  DuplicateKeyError,
+};

--- a/lib/plugin-loki.js
+++ b/lib/plugin-loki.js
@@ -27,6 +27,7 @@
 'use strict'
 
 const Loki = require('lokijs')
+const { DuplicateKeyError } = require('./errors')
 
 // mandatory plugin initialization - start
 const path = require('path')
@@ -232,6 +233,13 @@ function loadHandler () {
     try {
       users.insert(userObj)
     } catch (err) {
+      const { message } = err;
+
+      // translate lokijs error //
+      if (message && message.startsWith('Duplicate key for property')) {
+        throw new DuplicateKeyError(message, err)
+      }
+
       throw err
     }
     return null

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -25,6 +25,7 @@ const path = require('path')
 const callsite = require('callsite')
 const utils = require('../lib/utils')
 const endpointMap = require('../lib/endpointMap')
+const { DuplicateKeyError } = require('./errors')
 let scimDef = null
 let isMailLock = false
 
@@ -389,7 +390,7 @@ let ScimGateway = function () {
     const tx = scimDef.Schemas.Resources.find(el => el.name === schemaName)
     if (!tx) {
       let err = new Error(`Schema '${schemaName}' not found`)
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 404
       ctx.body = err
     } else {
@@ -416,7 +417,7 @@ let ScimGateway = function () {
       let data = await this[handle.getMethod](ctx.params.baseEntity, id, ctx.query.attributes ? ctx.query.attributes : '')
       if (!data || JSON.stringify(data) === '{}') {
         let err = new Error(`${handle.description} ${id} not found`)
-        err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+        err = jsonErr(config.scim.version, pluginName, ctx.status, err)
         ctx.status = 404
         ctx.body = err
       } else {
@@ -431,7 +432,7 @@ let ScimGateway = function () {
         ctx.body = data
       }
     } catch (err) {
-      let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 404
       ctx.body = e
     }
@@ -464,7 +465,7 @@ let ScimGateway = function () {
         ctx.body = scimdata
         return null
       } catch (err) {
-        let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+        let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
         ctx.status = 500
         ctx.body = e
         return null
@@ -547,7 +548,7 @@ let ScimGateway = function () {
             if (!data) data = {}
             if (!isScimv2 && JSON.stringify(data) === '{}') { // user/group not found, scim1.1 => http 404, scim2.0 http 200 and empty resource
               let err = new Error(`${handle.description} ${identifier} not found`)
-              err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+              err = jsonErr(config.scim.version, pluginName, ctx.status, err)
               ctx.status = 404
               ctx.body = err
               return null
@@ -565,7 +566,7 @@ let ScimGateway = function () {
               return null
             }
           } catch (err) {
-            let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+            let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
             ctx.status = 404
             ctx.body = e
             return null
@@ -586,21 +587,21 @@ let ScimGateway = function () {
             ctx.body = scimdata
             return null
           } catch (err) {
-            let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+            let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
             ctx.status = 500
             ctx.body = e
             return null
           }
         } else {
           let err = `GET /${handle.description}?filter="Incorrect filter definition" must include ${handle.uniqueAttr} (or id) and eq"`
-          err = jsonErr(config.scimversion, '', ctx.status, err)
+          err = jsonErr(config.scim.version, '', ctx.status, err)
           ctx.status = 400
           ctx.body = err
           return null
         }
       } else {
         let err = `GET /${handle.description}?filter="Incorrect filter definition"`
-        err = jsonErr(config.scimversion, '', ctx.status, err)
+        err = jsonErr(config.scim.version, '', ctx.status, err)
         ctx.status = 400
         ctx.body = err
         return null
@@ -632,19 +633,19 @@ let ScimGateway = function () {
     let strBody = JSON.stringify(jsonBody)
     if (strBody === '{}') {
       let err = new Error('Not accepting empty or none JSON formatted POST requests')
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = err
       return null
     } else if (handle.createMethod === 'createUser' && !jsonBody.userName && !jsonBody.externalId) {
       let err = new Error('userName or externalId is mandatory')
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = err
       return null
     } else if (handle.createMethod === 'createGroup' && !jsonBody.displayName && !jsonBody.externalId) {
       let err = new Error('displayName or externalId is mandatory')
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = err
       return null
@@ -666,7 +667,14 @@ let ScimGateway = function () {
       ctx.status = 201
       ctx.body = jsonBody
     } catch (err) {
-      let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      if (err instanceof DuplicateKeyError) {
+        let e = jsonErr(config.scim.version, pluginName, err.statusCode, err.originalError);
+        ctx.status = err.statusCode
+        ctx.body = e
+        return;
+      }
+
+      let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = e
     }
@@ -696,7 +704,7 @@ let ScimGateway = function () {
       await this[handle.deleteMethod](ctx.params.baseEntity, id)
       ctx.status = 204
     } catch (err) {
-      let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = e
     }
@@ -735,7 +743,7 @@ let ScimGateway = function () {
     let strBody = JSON.stringify(jsonBody)
     if (strBody === '{}') {
       let err = new Error('Not accepting empty or none JSON formatted POST requests')
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = err
     } else {
@@ -756,7 +764,7 @@ let ScimGateway = function () {
         ctx.status = 200
         ctx.body = jsonBody // using original body instead of retrieving actual data
       } catch (err) {
-        let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+        let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
         ctx.status = 500
         ctx.body = e
       }
@@ -778,7 +786,7 @@ let ScimGateway = function () {
     let strBody = JSON.stringify(jsonBody)
     if (strBody === '{}') {
       let err = new Error('Not accepting empty or none JSON formatted POST requests')
-      err = jsonErr(config.scimversion, pluginName, ctx.status, err)
+      err = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.status = 500
       ctx.body = err
     } else {
@@ -799,7 +807,7 @@ let ScimGateway = function () {
         ctx.status = 200
         ctx.body = jsonBody // using original body instead of retrieving actual data
       } catch (err) {
-        let e = jsonErr(config.scimversion, pluginName, ctx.status, err)
+        let e = jsonErr(config.scim.version, pluginName, ctx.status, err)
         ctx.status = 500
         ctx.body = e
       }


### PR DESCRIPTION
## Details
* Fixes error handling by changing expression `config.scimversion` to `config.scim.version`
* Improved handling of 'duplicate key' errors in `lib/plugin-loki.js`
* Updated `config/plugin-loki.js` to be SCIM 2.0
* Updated documentation to be consistent with `config/*.json` templates

### Bonus
* This branch passes the [Okta SCIM 2.0 Spec Test](https://www.okta.com/integrate/documentation/scim/#step-2-test-your-scim-server) (sort of)

There is one test I had to modify to get it to pass: **Optional Test: Check if Schemas is read-only**

As provided from Okta, the test is specifying `Content-Type: application/scim+json; charset=utf-8` but it is not providing a well formatted JSON value for the `body` ... this results in a 400 response code as the server is not able to parse garbage input (and I think this response is reasonable given the bad request).  I modified `body` to be `{ "test": "value" }` and it passes.  

The issue is in the currently available [Okta SCIM 2.0 Spec Test JSON](https://developer.okta.com/standards/SCIM/SCIMFiles/Okta-SCIM-20-SPEC-Test.json) file around line 383 (a working value is `"body": "{ \"test\":\"value\" }",`) 

I am working to submit a bug report to Okta and see if they will consider updating the spec file.