### PR TITLE
Added new expected Azure token audience for non-gallery applications

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -178,7 +178,14 @@ const ScimGateway = function () {
     loggingLevel: null,
     identityMetadata: `https://login.microsoftonline.com/${config.auth.bearer.jwt.azure.tenantIdGUID}/.well-known/openid-configuration`,
     clientID: '00000014-0000-0000-c000-000000000000', // Well known appid: Microsoft.Azure.SyncFabric
-    audience: '00000002-0000-0000-c000-000000000000', // Well know appid: Issued for accessing Windows Azure Active Directory Graph Webservice
+    audience: [
+      // New appid used for SCIM provisioning for non-gallery applications. See changes introduced, in reverse cronological order:
+      // - https://github.com/MicrosoftDocs/azure-docs/commit/f6997c0952d2ad4f33ce7f5339eeb83c21b51f1e
+      // - https://github.com/MicrosoftDocs/azure-docs/commit/64525fea0675a73b2e6b8fe42fbd03ee568cadfc
+      '8adf8e6e-67b2-4cf2-a259-e3dc5476c621',
+      // Well known appid: Issued for accessing Windows Azure Active Directory Graph Webservice
+      '00000002-0000-0000-c000-000000000000'
+    ],
     issuer: `https://sts.windows.net/${config.auth.bearer.jwt.azure.tenantIdGUID}/`
   }
 


### PR DESCRIPTION
Azure AD changed the application id used for SCIM provisioning for custom (i.e. non gallery) applications. See https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/use-scim-to-provision-users-and-groups#handling-endpoint-authentication

The change introduced by Azure AD is also documented by the following commits (in reverse cronological order):
https://github.com/MicrosoftDocs/azure-docs/commit/f6997c0952d2ad4f33ce7f5339eeb83c21b51f1e
https://github.com/MicrosoftDocs/azure-docs/commit/64525fea0675a73b2e6b8fe42fbd03ee568cadfc

My proposal is to keep both the old app id and the new one because, from my tests, existing application still use the old id, whereas newly created applications would use the new id.