### PR TITLE
Content Type validation breaks provisioning from Azure AD

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -340,8 +340,9 @@ const ScimGateway = function () {
 
   const verifyContentType = (ctx, next) => {
     return new Promise((resolve) => {
-      if (ctx.request.header['content-length']) { // body is included - invalid content-type gives empty body (koa-bodyparser)
-        if (ctx.request.header['content-type'] && (ctx.request.header['content-type'].toLowerCase() === 'application/json' || ctx.request.header['content-type'].toLowerCase() === 'application/scim+json')) {
+      if (ctx.request.length) { // body is included - invalid content-type gives empty body (koa-bodyparser)
+        const contentType = ctx.request.type.toLowerCase()
+        if (contentType === 'application/json' || contentType === 'application/scim+json') {
           return resolve(next())
         }
         ctx.status = 415


### PR DESCRIPTION
The Content-Type header validation breaks provisioning from Azure AD.

https://github.com/jelhub/scimgateway/blob/1047fd50265b3a4d7170de409e07f8e84488338d/lib/scimgateway.js#L341-L353

More in particular, the above function expects the Content-Type header to be strictly equal to either `application/json` or `application/scim+json` values.
The Azure AD provisioning service uses instead the `application/scim+json; charset=utf-8` value, i.e. it also specifies the charset parameter.

To solve this, I used the Koa provided `request.type` property, which returns the request Content-Type header void of parameters such as "charset", or an empry string if the header is not defined (see https://github.com/koajs/koa/blob/master/docs/api/request.md#requesttype).