### PR TITLE
Fix patch on multi-value attributes

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -1552,9 +1552,9 @@ const convertedScim20 = (data) => {
         pathRoot = arrMatches[1]
       } else if (Array.isArray(arrMatches) && arrMatches.length === 3) {
         if (type) {
-          path = `${arrMatches[1]}.${type}${arrMatches[2]}`
+          path = `${arrMatches[1]}.${type}.${arrMatches[2]}`
           typeElement = arrMatches[2] // streetAddress
-        } else path = `${arrMatches[1]}${arrMatches[2]}` // NA
+        } else path = `${arrMatches[1]}.${arrMatches[2]}` // NA
         pathRoot = arrMatches[1]
       }
       if ((element.op).toLowerCase() === 'replace' || (element.op).toLowerCase() === 'add') {


### PR DESCRIPTION
PATCH operations on multi-value attributes (e.g. `emails[type eq \"work\"].value`) are not properly working. 

For instance, considering the following request:
```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ],
    "Operations": [
        {
            "op": "Add",
            "path": "emails[type eq \"work\"].value",
            "value": "foo@example.com"
        }
    ]
}
```
the operation would fail with the following error reponse:
```json
{
    "statusCode": 500,
    "statusMessage": "Internal Server Error",
    "body": {
        "schemas": [
            "urn:ietf:params:scim:api:messages:2.0:Error"
        ],
        "detail": "ScimGateway[plugin-loki] TypeError: Cannot create property 'type' on string 'foo@example.com'",
        "status": 404
    }
}
```
This seems to be caused by the change introduced in [620e16b](https://github.com/jelhub/scimgateway/commit/620e16baa6445b71e7880cadae6e77e0f3c3dad1#diff-35337f849749b183f9532b9baf388c3aL1454-R1452).
More in particular, with that change, the `.` separator between type selector (e.g. `[type eq \"work\"]`) and sub-field (e.g. `value`) is no longer part of the regular expression's second capturing group (i.e. `arrMatches[2]`). As a consequence, path becomes `emails.workvalue`, whereas the expected path is **`emails.work.value`**.

The proposed solution is simply to explicitly add the `.` separator where required.