### PR TITLE
Return 500 on GET handler error instead of 404

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -739,7 +739,7 @@ const ScimGateway = function () {
           scimdata = addSchemas(scimdata, handle.description, isScimv2)
           ctx.body = scimdata
         } catch (err) {
-          ctx.status = 404
+          ctx.status = 500
           const e = jsonErr(config.scim.version, pluginName, ctx.status, err)
           ctx.body = e
         }


### PR DESCRIPTION
Empty response turns a 200 with empty Resources array.