### PR TITLE
add support for interpolation of raw text secrets files (issue #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Definitions in `endpoint` object are customized according to our plugin code. Pl
 - Setting environment variable `SEED` will override default password seeding logic.  
 - All configuration can be set based on environment variables. Syntax will then be `"process.env.<ENVIRONMENT>"` where `<ENVIRONMENT>` is the environment variable used. E.g. scimgateway.port could have value "process.env.PORT", then using environment variable PORT.
 - All configuration can be set based on corresponding JSON-content (dot notation) in external file using plugin name as parent JSON object. Syntax will then be `"process.file.<path>"` where `<path>` is the file used. E.g. endpoint.password could have value "process.file./var/run/vault/secrets.json"  
+- Indivudual Secrets can be contained in plain text files. Syntax will then be `"process.text.<path>"` where `<path>` is the file which contains raw (`UTF-8`) character value. E.g. endpoint.password could have value "process.text./var/run/vault/endpoint.password". This enables that the config file itself be loaded from a ConfigMap while specific values are mounted either from `secrets.json` style files as mentioned above OR from traditional secrets files mounted in the file system, one value per file.
 
 	Example:  
 
@@ -404,6 +405,11 @@ Definitions in `endpoint` object are customized according to our plugin code. Pl
 		        },
 		        ...
 		      ],
+		      "bearerJwt": [
+		         "secret": "process.text./var/run/vault/jwt.secret",
+		         "publicKey": "process.text./var/run/vault/jwt.pub",
+				 ...
+			  ],
 		      ...
 		    },
 		  "endpoint": {

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -1663,7 +1663,9 @@ const getMultivalueTypes = (objName, scimDef) => { // objName = 'User' or 'Group
 ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, config, isMain) {
   const processEnv = 'process.env.'
   const processFile = 'process.file.'
+  const processText = 'process.text.'
   const dotConfig = dot.dot(config)
+  const processTexts = new Map();
   const processFiles = new Map();
 
   for (const key in dotConfig) {
@@ -1677,14 +1679,26 @@ ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, 
         newErr.name = 'processExtConfig'
         throw newErr
       }
-    } else if (value && value.constructor === String && value.includes(processFile)) {
-      const newFilePath = value.substring(processFile.length)
+    } else if (value && value.constructor === String && value.includes(processText)) {
+      const filePath = value.substring(processText.length)
       try {
-        if (!processFiles.has(newFilePath)) { // avoid reading previous file
-          processFiles.set(newFilePath, JSON.parse(fs.readFileSync(filePath, 'utf8')))
+        if (!processTexts.has(filePath)) { // avoid reading previous file
+          processTexts.set(filePath, fs.readFileSync(filePath, 'utf8'))
+        }
+        value = processTexts.get(filePath) // directly a string
+      } catch (err) {
+        value = undefined
+        throw new Error(`configuration failed - can't read text from external file: "${filePath}"`)
+      }
+      dotConfig[key] = value
+    } else if (value && value.constructor === String && value.includes(processFile)) {
+      const filePath = value.substring(processFile.length)
+      try {
+        if (!processFiles.has(filePath)) { // avoid reading previous file
+          processFiles.set(filePath, JSON.parse(fs.readFileSync(filePath, 'utf8')))
         }
         try {
-          const jContent = processFiles.get(newFilePath) // json or json-dot-notation formatting is supported
+          const jContent = processFiles.get(filePath) // json or json-dot-notation formatting is supported
           const dotContent = dot.dot(dot.object(jContent))
           let newKey = null
           if (isMain) newKey = `${pluginName}.scimgateway.${key}`
@@ -1719,6 +1733,7 @@ ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, 
       dotConfig[key] = value
     }
   }
+  processTexts.clear()
   processFiles.clear()
   return dot.object(dotConfig)
 }

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -1664,8 +1664,7 @@ ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, 
   const processEnv = 'process.env.'
   const processFile = 'process.file.'
   const dotConfig = dot.dot(config)
-  let content
-  let filePath
+  const processFiles = new Map();
 
   for (const key in dotConfig) {
     let value = dotConfig[key]
@@ -1681,12 +1680,11 @@ ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, 
     } else if (value && value.constructor === String && value.includes(processFile)) {
       const newFilePath = value.substring(processFile.length)
       try {
-        if (filePath !== newFilePath) { // avoid reading previous file
-          filePath = newFilePath
-          content = fs.readFileSync(filePath, 'utf8')
+        if (!processFiles.has(newFilePath)) { // avoid reading previous file
+          processFiles.set(newFilePath, JSON.parse(fs.readFileSync(filePath, 'utf8')))
         }
         try {
-          const jContent = JSON.parse(content) // json or json-dot-notation formatting is supported
+          const jContent = processFiles.get(newFilePath) // json or json-dot-notation formatting is supported
           const dotContent = dot.dot(dot.object(jContent))
           let newKey = null
           if (isMain) newKey = `${pluginName}.scimgateway.${key}`
@@ -1721,7 +1719,7 @@ ScimGateway.prototype.processExtConfig = function processExtConfig (pluginName, 
       dotConfig[key] = value
     }
   }
-  content = null
+  processFiles.clear()
   return dot.object(dotConfig)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,11 +69,17 @@ module.exports.getPassword = function (pwDotNotation, configFile) {
     if (pw.includes('process.')) { // password based on external reference e.g. environment or json file
       // syntax environment = "process.env.<ENVIRONMENT>" e.g. scimgateway.password could have value "process.env.PORT", then using environment variable PORT
       // syntax file = "process.file.<PATH>" e.g. scimgateway.password could have value "process.file./tmp/myconf.json"
+      const processText = 'process.text.'
       const processEnv = 'process.env.'
       const processFile = 'process.file.'
       if (pw.constructor === String && pw.includes(processEnv)) {
         const envKey = pw.substring(processEnv.length)
         pwclear = process.env[envKey]
+      } else if (pw && pw.constructor === String && pw.includes(processText)) {
+        const filePath = pw.substring(processFile.length)
+        try {
+          pwclear = fs.readFileSync(filePath, 'utf8')
+        } catch (err) { pwclear = undefined } // can't read external configuration file
       } else if (pw && pw.constructor === String && pw.includes(processFile)) {
         const filePath = pw.substring(processFile.length)
         try {


### PR DESCRIPTION
### From the README

Indivudual Secrets can be contained in plain text files. Syntax will then be `"process.text.<path>"` where `<path>` is the file which contains raw (`UTF-8`) character value. E.g. endpoint.password could have value "process.text./var/run/vault/endpoint.password". This enables that the config file itself be loaded from a ConfigMap while specific values are mounted either from `secrets.json` style files as mentioned above OR from traditional secrets files mounted in the file system, one value per file.