### PR TITLE
OIIMT-370 + Request payload size configurable in the config

### DIFF
--- a/config/plugin-api.json
+++ b/config/plugin-api.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8890,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-api.json
+++ b/config/plugin-api.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8890,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,
@@ -87,9 +87,7 @@
   "endpoint": {
     "entity": {
       "undefined": {
-        "baseUrls": [
-          "http://fakerestapi.azurewebsites.net"
-        ],
+        "baseUrls": ["http://fakerestapi.azurewebsites.net"],
         "username": "endpointuser",
         "password": "password",
         "proxy": {

--- a/config/plugin-azure-ad.json
+++ b/config/plugin-azure-ad.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8881,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "1.1",
       "customSchema": null,

--- a/config/plugin-azure-ad.json
+++ b/config/plugin-azure-ad.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8881,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "1.1",
       "customSchema": null,

--- a/config/plugin-forwardinc.json
+++ b/config/plugin-forwardinc.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8882,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-forwardinc.json
+++ b/config/plugin-forwardinc.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8882,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-ldap.json
+++ b/config/plugin-ldap.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8883,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-ldap.json
+++ b/config/plugin-ldap.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8883,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,
@@ -87,10 +87,7 @@
   "endpoint": {
     "entity": {
       "undefined": {
-        "baseUrls": [
-          "ldaps://dc1.test.com:636",
-          "ldaps://dc2.test.com:636"
-        ],
+        "baseUrls": ["ldaps://dc1.test.com:636", "ldaps://dc2.test.com:636"],
         "username": "CN=Administrator,CN=Users,DC=test,DC=com",
         "password": "password",
         "ldap": {
@@ -106,10 +103,7 @@
             "organizationalPerson",
             "top"
           ],
-          "groupObjectClasses": [
-            "group",
-            "top"
-          ]
+          "groupObjectClasses": ["group", "top"]
         }
       }
     },

--- a/config/plugin-loki.json
+++ b/config/plugin-loki.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8880,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-loki.json
+++ b/config/plugin-loki.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8880,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-mongodb.json
+++ b/config/plugin-mongodb.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8885,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-mongodb.json
+++ b/config/plugin-mongodb.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8885,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-mssql.json
+++ b/config/plugin-mssql.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8888,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-mssql.json
+++ b/config/plugin-mssql.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8888,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-saphana.json
+++ b/config/plugin-saphana.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8884,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-saphana.json
+++ b/config/plugin-saphana.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8884,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-scim.json
+++ b/config/plugin-scim.json
@@ -2,6 +2,7 @@
   "scimgateway": {
     "port": 8886,
     "localhostonly": false,
+    "payloadSize": "1mb",
     "scim": {
       "version": "2.0",
       "customSchema": null,

--- a/config/plugin-scim.json
+++ b/config/plugin-scim.json
@@ -2,7 +2,7 @@
   "scimgateway": {
     "port": 8886,
     "localhostonly": false,
-    "payloadSize": "1mb",
+    "payloadSize": null,
     "scim": {
       "version": "2.0",
       "customSchema": null,
@@ -87,9 +87,7 @@
   "endpoint": {
     "entity": {
       "undefined": {
-        "baseUrls": [
-          "http://localhost:8880"
-        ],
+        "baseUrls": ["http://localhost:8880"],
         "scimVersion": "2.0",
         "username": "gwadmin",
         "password": "password",
@@ -100,9 +98,7 @@
         }
       },
       "clientA": {
-        "baseUrls": [
-          "http://localhost:8880"
-        ],
+        "baseUrls": ["http://localhost:8880"],
         "scimVersion": "2.0",
         "username": "gwadmin",
         "password": "password",

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -578,7 +578,8 @@ const ScimGateway = function () {
   app.use(bodyParser({ // parsed body store in ctx.request.body
     enableTypes: ['json', 'form'],
     extendTypes: { json: ['application/scim+json', 'text/plain'] },
-    formTypes: { form: ['application/x-www-form-urlencoded'] }
+    formTypes: { form: ['application/x-www-form-urlencoded'] },
+    jsonLimit: config.payloadSize !== undefined ? config.payloadSize : '1mb',
   }))
   app.use(ipAllowList)
   app.use(auth) // authentication before routes

--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -579,7 +579,7 @@ const ScimGateway = function () {
     enableTypes: ['json', 'form'],
     extendTypes: { json: ['application/scim+json', 'text/plain'] },
     formTypes: { form: ['application/x-www-form-urlencoded'] },
-    jsonLimit: config.payloadSize !== undefined ? config.payloadSize : '1mb',
+    jsonLimit: (!config.payloadSize) ? undefined : config.payloadSize // default '1mb'
   }))
   app.use(ipAllowList)
   app.use(auth) // authentication before routes


### PR DESCRIPTION
Issue this PR references #69 

User configurable payload size. Set to 1mb as default (which is the previous default for body-parser). Fallback value to 1mb if config option doesn't exist (makes it backwards compatible).