### PR TITLE
Add PassThrough auth token

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -109,6 +109,7 @@ const ScimGateway = function () {
 
   let foundBasic = false
   let foundBearerToken = false
+  let foundBearerTokenPassThrough = false
   let foundBearerJwtAzure = false
   let foundBearerJwt = false
   let foundBearerOAuth = false
@@ -143,6 +144,8 @@ const ScimGateway = function () {
     }
     if (!foundBearerToken) config.auth.bearerToken = []
   }
+
+  if (config.auth.bearerTokenPassThrough) foundBearerTokenPassThrough = true
 
   if (Array.isArray(config.auth.bearerJwtAzure)) {
     const issuers = []
@@ -223,7 +226,7 @@ const ScimGateway = function () {
   if (config.certificate.pfx.password) pwPfxPassword = ScimGateway.prototype.getPassword('scimgateway.certificate.pfx.password', configFile)
   if (config.emailOnError.smtp.password) config.emailOnError.smtp.password = ScimGateway.prototype.getPassword('scimgateway.emailOnError.smtp.password', configFile)
 
-  if (!foundBasic && !foundBearerToken && !foundBearerJwtAzure && !foundBearerJwt && !foundBearerOAuth) {
+  if (!foundBasic && !foundBearerToken && !foundBearerTokenPassThrough && !foundBearerJwtAzure && !foundBearerJwt && !foundBearerOAuth) {
     logger.error(`${gwName}[${pluginName}] Scimgateway password decryption failed or no password defined`)
     logger.error(`${gwName}[${pluginName}] stopping...\n`)
     throw (new Error('Using exception to stop further asynchronous code execution (ensure synchronous logger flush to logfile and exit program), please ignore this one...'))
@@ -317,9 +320,8 @@ const ScimGateway = function () {
   }
 
   // start auth methods - used by auth
-  const basic = (baseEntity, method, authType, authToken, url) => {
+  const basic = (baseEntity, method, authType, authToken) => {
     return new Promise((resolve, reject) => { // basic auth
-      if (url === '/ping' || url.endsWith('/oauth/token') || url === '/_ah/start' || url === '/_ah/stop' || url === '/favicon.ico') resolve(true) // no auth
       if (authType !== 'Basic') resolve(false)
       if (!foundBasic) resolve(false) // not configured
       const [userName, userPassword] = (Buffer.from(authToken, 'base64').toString() || '').split(':')
@@ -363,6 +365,25 @@ const ScimGateway = function () {
       reject(new Error('bearerToken authentication failed'))
     })
   }
+
+  const bearerTokenPassThrough = (allowBearerTokenPassThrough, baseEntity, method, authType, authToken, ctx) => new Promise((resolve, reject) => { // bearer pass through token
+    if (!allowBearerTokenPassThrough) resolve(false);
+    if (authType !== 'Bearer' || !authToken) resolve(false);
+    if (!foundBearerTokenPassThrough || !authToken) resolve(false);
+    const authConfig = config.auth.bearerTokenPassThrough;
+    if (authConfig) {
+      if (authConfig.baseEntities) {
+        if (Array.isArray(authConfig.baseEntities) && authConfig.baseEntities.length > 0) {
+          if (!baseEntity) return reject(new Error(`baseEntity=${baseEntity} not allowed for this bearerToken according to bearerPassThrough configuration baseEntitites=${authConfig.baseEntities}`));
+          if (!authConfig.baseEntities.includes(baseEntity)) return reject(new Error(`baseEntity=${baseEntity} not allowed for this bearerToken according to bearerPassThrough configuration baseEntitites=${authConfig.baseEntities}`));
+        }
+      }
+      if (authConfig.readOnly === true && method !== 'GET') return reject(new Error('only allowing readOnly for this bearerToken according to bearerPassThrough configuration readOnly=true'));
+      ctx.state.authToken = authToken;
+      return resolve(true);
+    }
+    reject(new Error('bearerPassThrough authentication failed'));
+  });
 
   const bearerJwtAzure = (baseEntity, ctx, next, authType, authToken) => {
     return new Promise((resolve, reject) => {
@@ -476,7 +497,7 @@ const ScimGateway = function () {
 
   // end auth methods - used by auth
 
-  const auth = async (ctx, next) => { // authentication/authorization
+  const auth = (allowBearerTokenPassThrough) => async (ctx, next) => { // authentication/authorization
     const [authType, authToken] = (ctx.request.header.authorization || '').split(' ') // [0] = 'Basic' or 'Bearer'
     let baseEntity
     const arr = ctx.request.url.split('/')
@@ -486,8 +507,9 @@ const ScimGateway = function () {
     }
     try { // authenticate
       const arrResolve = await Promise.all([
-        basic(baseEntity, ctx.request.method, authType, authToken, ctx.url),
+        basic(baseEntity, ctx.request.method, authType, authToken),
         bearerToken(baseEntity, ctx.request.method, authType, authToken),
+        bearerTokenPassThrough(allowBearerTokenPassThrough, baseEntity, ctx.request.method, authType, authToken, ctx),
         bearerJwtAzure(baseEntity, ctx, next, authType, authToken),
         bearerJwt(baseEntity, ctx.request.method, authType, authToken),
         bearerOAuth(baseEntity, ctx.request.method, authType, authToken)])
@@ -584,7 +606,7 @@ const ScimGateway = function () {
     jsonLimit: (!config.payloadSize) ? undefined : config.payloadSize // default '1mb'
   }))
   app.use(ipAllowList)
-  app.use(auth) // authentication before routes
+  // app.use(auth) // authentication before routes
   app.use(verifyContentType)
   app.use(router.routes())
   app.use(router.allowedMethods())
@@ -615,7 +637,7 @@ const ScimGateway = function () {
   // If not included => Provisioning will always use GET /Users without any paramenters
   // scimv1 = ServiceProviderConfigs, scimv2 ServiceProviderConfig
   router.get(['/(|scim/)(ServiceProviderConfigs|ServiceProviderConfig)',
-    '/:baseEntity/(|scim/)(ServiceProviderConfigs|ServiceProviderConfig)'], async (ctx) => {
+    '/:baseEntity/(|scim/)(ServiceProviderConfigs|ServiceProviderConfig)'], auth(false), async (ctx) => {
     const tx = scimDef.ServiceProviderConfigs
     const location = ctx.origin + ctx.path
     if (tx.meta) tx.meta.location = location
@@ -628,7 +650,7 @@ const ScimGateway = function () {
   })
 
   // Initial connection, step #2: GET /Schemas
-  router.get(['/(|scim/)Schemas', '/:baseEntity/(|scim/)Schemas'], async (ctx) => {
+  router.get(['/(|scim/)Schemas', '/:baseEntity/(|scim/)Schemas'], auth(false), async (ctx) => {
     let tx = scimDef.Schemas
     tx = addResources(tx)
     tx = addSchemas(tx, null, isScimv2)
@@ -636,7 +658,7 @@ const ScimGateway = function () {
   })
 
   // oauth token request
-  router.post(['/(|scim/)oauth/token', '/:baseEntity/(|scim/)oauth/token'], async (ctx) => {
+  router.post(['/(|scim/)oauth/token', '/:baseEntity/(|scim/)oauth/token'], auth(false), async (ctx) => {
     logger.debug(`${gwName}[${pluginName}] [oauth] token request`)
     if (!foundBearerOAuth) {
       logger.error(`${gwName}[${pluginName}] [oauth] token request, but plugin is missing config.auth.bearerOAuth configuration`)
@@ -732,7 +754,7 @@ const ScimGateway = function () {
     ctx.body = tx
   })
 
-  router.get(['/(|scim/)Schemas/:id', '/:baseEntity/(|scim/)Schemas/:id'], async (ctx) => { // e.g /Schemas/Users | Groups | ServiceProviderConfigs
+  router.get(['/(|scim/)Schemas/:id', '/:baseEntity/(|scim/)Schemas/:id'], auth(false), async (ctx) => { // e.g /Schemas/Users | Groups | ServiceProviderConfigs
     let schemaName = ctx.params.id
     if (schemaName.substr(schemaName.length - 1) === 's') schemaName = schemaName.substr(0, schemaName.length - 1)
     const tx = scimDef.Schemas.Resources.find(el => el.name === schemaName)
@@ -747,13 +769,12 @@ const ScimGateway = function () {
   })
 
   router.get(['/(|scim/)(ResourceTypes|ResourceType)',
-    '/:baseEntity/(|scim/)(ResourceTypes|ResourceType)'], async (ctx) => { // ResourceTypes according to v2 specification
+    '/:baseEntity/(|scim/)(ResourceTypes|ResourceType)'], auth(false), async (ctx) => { // ResourceTypes according to v2 specification
     const tx = scimDef.ResourceType
     ctx.body = tx
   })
-
-  router.get([`/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`,
-  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`], async (ctx) => {
+  
+  const getEntity = async (ctx) => {
     if (ctx.query.attributes) ctx.query.attributes = ctx.query.attributes.split(',').map(item => item.trim()).join()
     if (ctx.query.excludedAttributes) ctx.query.excludedAttributes = ctx.query.excludedAttributes.split(',').map(item => item.trim()).join()
     let u = ctx.originalUrl.substr(0, ctx.originalUrl.lastIndexOf('/'))
@@ -771,7 +792,7 @@ const ScimGateway = function () {
     logger.debug(`${gwName}[${pluginName}] calling "${handle.getMethod}" and awaiting result`)
 
     try {
-      const res = await this[handle.getMethod](ctx.params.baseEntity, utils.copyObj(getObj), ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [])
+      const res = await this[handle.getMethod](ctx.params.baseEntity, utils.copyObj(getObj), ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [], ctx.state.authToken)
 
       let scimdata = {
         Resources: [],
@@ -802,7 +823,7 @@ const ScimGateway = function () {
           logger.debug(`${gwName}[${pluginName}] calling "${handler.groups.getMethod}" and awaiting result - groups to be included`)
           let res
           try {
-            res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: getObj.value }, ['id', 'displayName'])
+            res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: getObj.value }, ['id', 'displayName'], ctx.state.authToken)
           } catch (err) {} // method may be implemented but throwing error like groups not supported/implemented
           if (res && res.Resources && Array.isArray(res.Resources) && res.Resources.length > 0) {
             userObj.groups = []
@@ -832,14 +853,18 @@ const ScimGateway = function () {
       const e = jsonErr(config.scim.version, pluginName, ctx.status, err)
       ctx.body = e
     }
-  })
+  }
+
+  router.get([`/(|scim/)(!${undefined}|Users|Groups)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)/:id`], auth(true), getEntity)
+  router.get([`/(|scim/)(!${undefined}|servicePlans)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|servicePlans)/:id`], auth(false), getEntity)
 
   // ==========================================
   //           getUsers
   //           getGroups
   // ==========================================
-  router.get(['/(|scim/)(Users|Groups|servicePlans)',
-    '/:baseEntity/(|scim/)(Users|Groups|servicePlans)'], async (ctx) => {
+  const getEntities = async (ctx) => {
     if (ctx.query.attributes) ctx.query.attributes = ctx.query.attributes.split(',').map(item => item.trim()).join()
     if (ctx.query.excludedAttributes) ctx.query.excludedAttributes = ctx.query.excludedAttributes.split(',').map(item => item.trim()).join()
     let u = ctx.originalUrl.substr(ctx.originalUrl.lastIndexOf('/') + 1) // u = Users, Groups, servicePlans, ...
@@ -981,7 +1006,7 @@ const ScimGateway = function () {
       if (getObj.startIndex && !getObj.count) getObj.count = 200 // defaults to 200 (plugin may override)
       if (getObj.count && !getObj.startIndex) getObj.startIndex = 1
 
-      const res = await this[handle.getMethod](ctx.params.baseEntity, utils.copyObj(getObj), ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [])
+      const res = await this[handle.getMethod](ctx.params.baseEntity, utils.copyObj(getObj), ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [], ctx.state.authToken)
       let scimdata = {
         Resources: [],
         totalResults: null
@@ -1006,7 +1031,7 @@ const ScimGateway = function () {
             logger.debug(`${gwName}[${pluginName}] calling "${handler.groups.getMethod}" and awaiting result - groups to be included`)
             let res
             try {
-              res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: decodeURIComponent(userObj.id) }, ['id', 'displayName']) // await scimgateway.getUserGroups(baseEntity, userObj.id, 'members.value,displayName')
+              res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: decodeURIComponent(userObj.id) }, ['id', 'displayName'], ctx.state.authToken) // await scimgateway.getUserGroups(baseEntity, userObj.id, 'members.value,displayName')
             } catch (err) {} // method may be implemented but throwing error like groups not supported/implemented
             if (res && res.Resources && Array.isArray(res.Resources) && res.Resources.length > 0) {
               userObj.groups = []
@@ -1041,7 +1066,12 @@ const ScimGateway = function () {
       const e = jsonErr(config.scim.version, pluginName, ctx.status, err, scimType)
       ctx.body = e
     }
-  })
+  }
+
+  router.get(['/(|scim/)(Users|Groups)',
+    '/:baseEntity/(|scim/)(Users|Groups)'], auth(true), getEntities)
+  router.get(['/(|scim/)(servicePlans)',
+    '/:baseEntity/(|scim/)(servicePlans)'], auth(false), getEntities)
 
   // ==========================================
   //           createUser
@@ -1059,7 +1089,7 @@ const ScimGateway = function () {
   // {"displayName":"MyGroup","externalId":"MyExternal","schemas":["urn:scim:schemas:core:1.0"]}
   //
   router.post([`/(|scim/)(!${undefined}|Users|Groups)(|.json)(|.xml)`,
-  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)(|.json)(|.xml)`], async (ctx) => {
+  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)(|.json)(|.xml)`], auth(true), async (ctx) => {
     let u = ctx.originalUrl.substr(ctx.originalUrl.lastIndexOf('/') + 1) // u = Users<.json|.xml>, Groups<.json|.xml>
     u = u.split('?')[0] // Users?AzureAdScimPatch062020
     const handle = handler[u.split('.')[0]]
@@ -1099,7 +1129,7 @@ const ScimGateway = function () {
     logger.debug(`${gwName}[${pluginName}] calling "${handle.createMethod}" and awaiting result`)
     delete jsonBody.id // in case included in request
     try {
-      const res = await this[handle.createMethod](ctx.params.baseEntity, scimdata)
+      const res = await this[handle.createMethod](ctx.params.baseEntity, scimdata, ctx.state.authToken)
       for (const key in res) { // merge any result e.g: {'id': 'xxxx'}
         jsonBody[key] = res[key]
       }
@@ -1110,18 +1140,18 @@ const ScimGateway = function () {
           if (handle.createMethod === 'createUser') {
             if (jsonBody.userName) {
               jsonBody.id = jsonBody.userName
-              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'userName', operator: 'eq', value: jsonBody.userName }, ['id', 'userName'])
+              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'userName', operator: 'eq', value: jsonBody.userName }, ['id', 'userName'], ctx.state.authToken)
             } else if (jsonBody.externalId) {
               jsonBody.id = jsonBody.externalId
-              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'externalId', operator: 'eq', value: jsonBody.externalId }, ['id', 'externalId'])
+              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'externalId', operator: 'eq', value: jsonBody.externalId }, ['id', 'externalId'], ctx.state.authToken)
             }
           } else if (handle.createMethod === 'createGroup') {
             if (jsonBody.externalId) {
               jsonBody.id = jsonBody.externalId
-              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'externalId', operator: 'eq', value: jsonBody.externalId }, ['id', 'externalId'])
+              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'externalId', operator: 'eq', value: jsonBody.externalId }, ['id', 'externalId'], ctx.state.authToken)
             } else if (jsonBody.displayName) {
               jsonBody.id = jsonBody.displayName
-              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'displayName', operator: 'eq', value: jsonBody.displayName }, ['id', 'displayName'])
+              obj = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'displayName', operator: 'eq', value: jsonBody.displayName }, ['id', 'displayName'], ctx.state.authToken)
             }
           }
         } catch (err) { }
@@ -1163,7 +1193,7 @@ const ScimGateway = function () {
   // => We then have: DELETE /Groups/Employees
   //
   router.delete([`/(|scim/)(!${undefined}|Users|Groups)/:id`,
-  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)/:id`], async (ctx) => {
+  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)/:id`], auth(true), async (ctx) => {
     let u = ctx.originalUrl.substr(0, ctx.originalUrl.lastIndexOf('/'))
     u = u.substr(u.lastIndexOf('/') + 1) // u = Users, Groups
     const handle = handler[u]
@@ -1172,7 +1202,7 @@ const ScimGateway = function () {
     logger.debug(`${gwName}[${pluginName}] calling "${handle.deleteMethod}" and awaiting result`)
 
     try {
-      await this[handle.deleteMethod](ctx.params.baseEntity, id)
+      await this[handle.deleteMethod](ctx.params.baseEntity, id, ctx.state.authToken)
       ctx.status = 204
     } catch (err) {
       ctx.status = 500
@@ -1204,9 +1234,8 @@ const ScimGateway = function () {
   //
   // Body contains groups attributes to be updated
   // example: {"members":[{"value":"bjensen"}],"schemas":["urn:scim:schemas:core:1.0"]}
-  //
-  router.patch([`/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`,
-  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`], async (ctx) => {
+  //  
+  const modifyEntity = async (ctx) => {
     if (ctx.query.attributes) ctx.query.attributes = ctx.query.attributes.split(',').map(item => item.trim()).join()
     if (ctx.query.excludedAttributes) ctx.query.excludedAttributes = ctx.query.excludedAttributes.split(',').map(item => item.trim()).join()
     let u = ctx.originalUrl.substr(0, ctx.originalUrl.lastIndexOf('/'))
@@ -1234,11 +1263,11 @@ const ScimGateway = function () {
       }
       logger.debug(`${gwName}[${pluginName}] calling "${handle.modifyMethod}" and awaiting result`)
       try {
-        await this[handle.modifyMethod](ctx.params.baseEntity, id, scimdata)
+        await this[handle.modifyMethod](ctx.params.baseEntity, id, scimdata, ctx.state.authToken)
         if (ctx.query.attributes || ctx.query.excludedAttributes) {
           logger.debug(`${gwName}[${pluginName}] calling "${handle.getMethod}" and awaiting result`)
 
-          const res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [])
+          const res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, ctx.query.attributes ? ctx.query.attributes.split(',').map(item => item.trim()) : [], ctx.state.authToken)
           let scimdata = {
             Resources: [],
             totalResults: null
@@ -1265,14 +1294,18 @@ const ScimGateway = function () {
         ctx.body = e
       }
     }
-  }) // patch
+  } // patch
+
+  router.patch([`/(|scim/)(!${undefined}|Users|Groups)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)/:id`], auth(true), modifyEntity)
+  router.patch([`/(|scim/)(!${undefined}|servicePlans)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|servicePlans)/:id`], auth(false), modifyEntity)
 
   // ==========================================
   //          REPLACE USER
   //          REPLACE GROUP
-  // ==========================================
-  router.put([`/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`,
-  `/:baseEntity/(|scim/)(!${undefined}|Users|Groups|servicePlans)/:id`], async (ctx) => {
+  // ==========================================  
+  const replaceUser = async (ctx) => {
     let u = ctx.originalUrl.substr(0, ctx.originalUrl.lastIndexOf('/'))
     u = u.substr(u.lastIndexOf('/') + 1) // u = Users, Groups
     const handle = handler[u]
@@ -1289,7 +1322,7 @@ const ScimGateway = function () {
       try {
         // get current object
         logger.debug(`${gwName}[${pluginName}] calling "${handle.getMethod}" and awaiting result`)
-        let res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, [])
+        let res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, [], ctx.state.authToken)
 
         let currentObj = {}
         if (res && res.Resources && Array.isArray(res.Resources) && res.Resources.length === 1) currentObj = res.Resources[0]
@@ -1329,7 +1362,7 @@ const ScimGateway = function () {
 
         // update object
         logger.debug(`${gwName}[${pluginName}] calling "${handle.modifyMethod}" and awaiting result`)
-        await this[handle.modifyMethod](ctx.params.baseEntity, id, scimdata)
+        await this[handle.modifyMethod](ctx.params.baseEntity, id, scimdata, ctx.state.authToken)
 
         // add/remove groups
         if (jsonBody.groups && Array.isArray(jsonBody.groups)) { // only if groups included, { "groups": [] } will remove all existing
@@ -1341,7 +1374,7 @@ const ScimGateway = function () {
           else { // try to get current groups the standard way
             let res
             try {
-              res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: decodeURIComponent(id) }, ['id', 'displayName'])
+              res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: decodeURIComponent(id) }, ['id', 'displayName'], ctx.state.authToken)
             } catch (err) {} // method may be implemented but throwing error like groups not supported/implemented
             currentGroups = []
             if (res && res.Resources && Array.isArray(res.Resources) && res.Resources.length > 0) {
@@ -1392,12 +1425,12 @@ const ScimGateway = function () {
 
           const addGroups = async (grp) => {
             const obj = { members: [{ value: id }] }
-            return await this[handler.groups.modifyMethod](ctx.params.baseEntity, grp, obj)
+            return await this[handler.groups.modifyMethod](ctx.params.baseEntity, grp, obj, ctx.state.authToken)
           }
 
           const removeGroups = async (grp) => {
             const obj = { members: [{ operation: 'delete', value: id }] }
-            return await this[handler.groups.modifyMethod](ctx.params.baseEntity, grp, obj)
+            return await this[handler.groups.modifyMethod](ctx.params.baseEntity, grp, obj, ctx.state.authToken)
           }
 
           let errRemove
@@ -1424,7 +1457,7 @@ const ScimGateway = function () {
 
         // get updated object
         logger.debug(`${gwName}[${pluginName}] calling "${handle.getMethod}" and awaiting result`)
-        res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, [])
+        res = await this[handle.getMethod](ctx.params.baseEntity, { attribute: 'id', operator: 'eq', value: id }, [], ctx.state.authToken)
 
         scimdata = {}
         if (res && res.Resources && Array.isArray(res.Resources) && res.Resources.length === 1) scimdata = res.Resources[0]
@@ -1435,7 +1468,7 @@ const ScimGateway = function () {
         // include groups
         if (handle.getMethod === handler.users.getMethod && typeof this[handler.groups.getMethod] === 'function') {
           logger.debug(`${gwName}[${pluginName}] calling "${handler.groups.getMethod}" and awaiting result`)
-          const res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: id }, ['id', 'displayName'])
+          const res = await this[handler.groups.getMethod](ctx.params.baseEntity, { attribute: 'members.value', operator: 'eq', value: id }, ['id', 'displayName'], ctx.state.authToken)
           let grps = []
           if (res && res.Resources && Array.isArray(res.Resources)) grps = res.Resources
           else if (Array.isArray(res)) grps = res
@@ -1466,7 +1499,12 @@ const ScimGateway = function () {
         ctx.body = e
       }
     }
-  })
+  }
+
+  router.put([`/(|scim/)(!${undefined}|Users|Groups)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|Users|Groups)/:id`], auth(true), replaceUser)
+  router.put([`/(|scim/)(!${undefined}|servicePlans)/:id`,
+    `/:baseEntity/(|scim/)(!${undefined}|servicePlans)/:id`], auth(false), replaceUser)
 
   // ==========================================
   //           API POST (no SCIM)
@@ -1477,7 +1515,7 @@ const ScimGateway = function () {
   // Body example:
   // {"eventName":"AsignAccessRoleEvent","subjectName":"RACF_System-B","userID":"peter01"}
   //
-  router.post(['/api', '/:baseEntity/api'], async (ctx) => {
+  router.post(['/api', '/:baseEntity/api'], auth(false), async (ctx) => {
     logger.debug(`${gwName}[${pluginName}] [POST api]`)
     const apiObj = ctx.request.body
     const strBody = JSON.stringify(apiObj)
@@ -1522,7 +1560,7 @@ const ScimGateway = function () {
   // Body example:
   // {"eventName":"AsignAccessRoleEvent","subjectName":"RACF_System-B","userID":"peter01"}
   //
-  router.put(['/api/:id', '/:baseEntity/api/:id'], async (ctx) => {
+  router.put(['/api/:id', '/:baseEntity/api/:id'], auth(false), async (ctx) => {
     const id = ctx.params.id
     logger.debug(`${gwName}[${pluginName}] [PUT api ] id=${id}`)
     const apiObj = ctx.request.body
@@ -1568,7 +1606,7 @@ const ScimGateway = function () {
   // Body example:
   // {"eventName":"AsignAccessRoleEvent","subjectName":"RACF_System-B","userID":"peter01"}
   //
-  router.patch(['/api/:id', '/:baseEntity/api/:id'], async (ctx) => {
+  router.patch(['/api/:id', '/:baseEntity/api/:id'], auth(false), async (ctx) => {
     const id = ctx.params.id
     logger.debug(`${gwName}[${pluginName}] [PATCH api ] id=${id}`)
     const apiObj = ctx.request.body
@@ -1614,7 +1652,7 @@ const ScimGateway = function () {
   //  GET = /api/{id}
   //
   router.get(['/api', '/api/:id',
-    '/:baseEntity/api', '/:baseEntity/api/:id'], async (ctx) => {
+    '/:baseEntity/api', '/:baseEntity/api/:id'], auth(false), async (ctx) => {
     if (ctx.params.id) logger.debug(`${gwName}[${pluginName}] [GET api] id=${ctx.params.id}`)
     else logger.debug(`${gwName}[${pluginName}] [GET api]`)
 
@@ -1654,7 +1692,7 @@ const ScimGateway = function () {
   //
   //  DELETE = /api/{id}
   //
-  router.delete(['/api/:id', '/:baseEntity/api/:id'], async (ctx) => {
+  router.delete(['/api/:id', '/:baseEntity/api/:id'], auth(false), async (ctx) => {
     const id = ctx.params.id
     logger.debug(`${gwName}[${pluginName}] calling "deleteApi" and awaiting result`)
 


### PR DESCRIPTION
Add a new auth option called `BearerTokenPassThrough`. The difference between this option and `BearerToken` is that the token is passed directly to the plugin handlers.

Since scimgateway will not be able to authenticate the token, this auth method should not be used by any endpoints that do not direct to a plugin handler, such as `/(|scim/)(ServiceProviderConfigs|ServiceProviderConfig)`. In order to support these two scenarios, the auth middleware has been moved down to each router instead of being used globally. This also allows endpoints such as `/ping` to skip authentication.

The `bearerTokenPassThrough` will do some basic validation of the Bearer token. If it is enabled and if it is found, then the auth token will be added to the context state. This value will then be passed onto the plugin handlers where it can optionally be used.