### PR TITLE
Simplify passing ctx

### DIFF
--- a/lib/plugin-scim.js
+++ b/lib/plugin-scim.js
@@ -119,7 +119,7 @@ scimgateway.getUsers = async (baseEntity, getObj, attributes, ctx) => {
   }
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     } else if (!response.body) {
@@ -220,7 +220,7 @@ scimgateway.createUser = async (baseEntity, userObj, ctx) => {
   }
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -242,7 +242,7 @@ scimgateway.deleteUser = async (baseEntity, id, ctx) => {
   const body = null
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -330,7 +330,7 @@ scimgateway.modifyUser = async (baseEntity, id, attrObj, ctx) => {
   }
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -394,7 +394,7 @@ scimgateway.getGroups = async (baseEntity, getObj, attributes, ctx) => {
   }
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     } else if (!response.body) {
@@ -444,7 +444,7 @@ scimgateway.createGroup = async (baseEntity, groupObj, ctx) => {
   const body = { displayName: groupObj.displayName }
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -466,7 +466,7 @@ scimgateway.deleteGroup = async (baseEntity, id, ctx) => {
   const body = null
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -538,7 +538,7 @@ scimgateway.modifyGroup = async (baseEntity, id, attrObj, ctx) => {
   const path = `/Groups/${id}`
 
   try {
-    const response = await doRequest(baseEntity, method, path, body)
+    const response = await doRequest({ baseEntity, method, path, body, ctx })
     if (response.statusCode < 200 || response.statusCode > 299) {
       throw new Error(`${response.statusMessage} - ${JSON.stringify(response.body)}`)
     }
@@ -675,7 +675,7 @@ const updateServiceClient = (baseEntity, obj) => {
 //
 // doRequest - execute REST service
 //
-const doRequest = async (baseEntity, method, path, body, opt, retryCount) => {
+const doRequest = async ({ baseEntity, method, path, body, opt, retryCount, ctx }) => {
   try {
     const cli = await getServiceClient(baseEntity, method, path, opt)
     const options = cli.options
@@ -688,6 +688,9 @@ const doRequest = async (baseEntity, method, path, body, opt, retryCount) => {
         } else dataString = JSON.stringify(body)
         options.headers['Content-Length'] = Buffer.byteLength(dataString, 'utf8')
       }
+
+      // Example of using ctx to pass an authorization header
+      // options.headers['Authorization'] = ctx.request.header.authorization
 
       const reqType = (options.protocol.toLowerCase() === 'https:') ? https.request : http.request
       const req = reqType(options, (res) => {
@@ -740,7 +743,7 @@ const doRequest = async (baseEntity, method, path, body, opt, retryCount) => {
         retryCount++
         updateServiceClient(baseEntity, { baseUrl: config.entity[baseEntity].baseUrls[retryCount - 1] })
         scimgateway.logger.debug(`${pluginName}[${baseEntity}] ${(config.entity[baseEntity].baseUrls.length > 1) ? 'failover ' : ''}retry[${retryCount}] using baseUrl = ${_serviceClient[baseEntity].baseUrl}`)
-        const ret = await doRequest(baseEntity, method, path, body, opt, retryCount) // retry
+        const ret = await doRequest({ baseEntity, method, path, body, opt, retryCount, ctx }) // retry
         return ret // problem fixed
       } else {
         const newerr = new Error(err.message)


### PR DESCRIPTION
Call doRequest with an object rather than list of parameters Example added of how to use ctx.
Closes #90 