### PR TITLE
Add support for X-Forwarded-Path

### DIFF
--- a/lib/scimgateway.ts
+++ b/lib/scimgateway.ts
@@ -2165,7 +2165,8 @@ export class ScimGateway {
       if (xfHost) {
         const xfProto = headers.get('x-forwarded-proto')
         const xfPort = headers.get('x-forwarded-port')
-        return `${xfProto ? xfProto + '://' : ''}${xfHost}${xfPort ? ':' + xfPort : ''}`
+        const xfPath = headers.get('x-forwarded-path')
+        return `${xfProto ? xfProto + '://' : ''}${xfHost}${xfPort ? ':' + xfPort : ''}${xfPath ? xfPath : ''}`
       }
       return null
     }


### PR DESCRIPTION
Similar to #110, we are deploying the SCIM Gateway behind an nginx reverse proxy. However, we want to use the base URL `/scim/v2` in our externally-facing URLs. There seem to be three solutions:

1. Add the base path to the `X-Forwaded-Host` header. I rejected this option as it seems to abuse the purpose of this header, which may be used to just identify the host for other purposes.

1. Update the base path the SCIM Gateway is served from to mirror the external path (e.g., http://localhost:8001/scim/v2) and update the nginx configuration to something like the following. I felt this was less preferred as it requires that the external and internal paths match.
    ```
        location /scim/v2 {
            proxy_pass http://localhost:8001;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Forwarded-Host $http_host;
        }
    ```
1. Path the base path as a separate `X-Forwarded-Path` header and update the scimgateway code to include it when forming the origin. I settled on this option and this is what is included in this PR.
    ```
        location /scim/v2/ {
            proxy_pass http://localhost:8001/;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Forwarded-Host $http_host;
            proxy_set_header X-Forwarded-Path "/scim/v2";
        }
    ```