### PR TITLE
removing await and changing to for of loop

### DIFF
--- a/lib/plugin-loki.ts
+++ b/lib/plugin-loki.ts
@@ -581,7 +581,7 @@ scimgateway.modifyGroup = async (baseEntity, id, attrObj, ctx) => {
     if (!Array.isArray(attrObj.members)) {
       throw new Error(`${action} error: ${JSON.stringify(attrObj)} - correct syntax is { "members": [...] }`)
     }
-    await attrObj.members.forEach(async (el) => {
+    for (const el of attrObj.members) {
       if (el.operation && el.operation === 'delete') { // delete member from group
         if (!el.value) groupObj.members = [] // members=[{"operation":"delete"}] => no value, delete all members
         else {
@@ -589,7 +589,7 @@ scimgateway.modifyGroup = async (baseEntity, id, attrObj, ctx) => {
         }
       } else { // Add member to group
         if (el.value) {
-          const getObj = { attribute: 'id', operator: 'eq', value: el.value }
+          const getObj = {attribute: 'id', operator: 'eq', value: el.value}
           const usrs: any = await scimgateway.getUsers(baseEntity, getObj, ['id', 'displayName'], ctx) // check if user exist
           if (usrs && usrs.Resources && usrs.Resources.length === 1 && usrs.Resources[0].id === el.value) {
             const newMember = {
@@ -601,7 +601,7 @@ scimgateway.modifyGroup = async (baseEntity, id, attrObj, ctx) => {
           } else usersNotExist.push(el.value)
         }
       }
-    })
+    }
   }
 
   delete attrObj.members


### PR DESCRIPTION
Refactor loop to support proper async handling

This PR replaces the use of an await call inside a non-async-compatible loop (such as forEach) with a for...of loop to ensure correct asynchronous behavior.

Motivation
Using await inside a forEach loop can lead to unintended behavior, as forEach does not handle promises or await their resolution. Refactoring to a for...of loop allows the use of await in a clean and sequential manner, ensuring the asynchronous operations are properly awaited.

Changes
Replaced existing loop with for...of syntax to support await inside the loop.

Impact
Ensures proper execution order of async operations within the loop.

Improves code readability and correctness.

Testing
Verified that the async operations now execute sequentially.

No regressions observed in existing functionality.